### PR TITLE
Native Elpis+Samsung support for J-runner

### DIFF
--- a/J-Runner/Forms/About.cs
+++ b/J-Runner/Forms/About.cs
@@ -18,6 +18,7 @@ namespace JRunner.Forms
                                     "Nick Stefanou: Original J-Runner \nDevelopment and Software",
                                     "Orpheus: Updates to KV Info/Bugfixes",
                                     "SGCSam: 6717/9199 XeBuild Patches",
+                                    "wurthless-elektroniks: Hacked 7378 CB_B for Elpis+Samsung",
                                     "Xvistaman2005: XDKbuild",
         };
         static int contribloc = 0;

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -2164,6 +2164,12 @@ namespace JRunner
                     xPanel.setWBChecked(true);
                 }
 
+                // Elpis CB_B for Xenon consoles with CB 73xx
+                if( nand.bl.CB_A >= 7373 && nand.bl.CB_A <= 7378 )
+                {
+                    xPanel.setElpisChecked(true);
+                }
+
                 // Patches
                 xPanel.setXLUSBChecked(variables.foundXlUsb);
                 xPanel.setXLHDDChecked(variables.foundXlHdd);

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -2373,9 +2373,11 @@ namespace JRunner
                 string wb = "";
                 string smcp = "";
                 string cr4 = "";
+                string elpis = "";
                 if (xPanel.getWBChecked() > 0) wb = "_WB";
                 if (xPanel.getSMCPChecked()) smcp = "_SMC+";
                 else if (xPanel.getCR4Checked()) cr4 = "_CR4";
+                if (xPanel.getElpisChecked()) elpis = "_ELPIS";
 
                 switch (variables.ctype.ID)
                 {
@@ -2395,7 +2397,7 @@ namespace JRunner
                         variables.filename1 = Path.Combine(variables.rootfolder, @"common\xell-images\glitch2", variables.Glitch2_jasper + cr4 + smcp + ".ecc");
                         break;
                     case 8:
-                        variables.filename1 = Path.Combine(variables.rootfolder, @"common\xell-images\glitch2", variables.Glitch2_xenon + ".ecc"); // No CR4 or SMC+
+                        variables.filename1 = Path.Combine(variables.rootfolder, @"common\xell-images\glitch2", variables.Glitch2_xenon + elpis + ".ecc"); // No CR4 or SMC+
                         break;
                     case 9:
                         variables.filename1 = Path.Combine(variables.rootfolder, @"common\xell-images\glitch2", variables.Glitch2_corona + wb + cr4 + smcp + ".ecc");

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -922,7 +922,6 @@ namespace JRunner.Panels
         {
             if (chkWB.Checked) patches[7] = "-r WB";
             else if (chkWB4G.Checked) patches[7] = "-r WB4G";
-            else if (chkElpis.Checked) patches[7] = "-r ELPIS";
             else patches[7] = "";
 
             updateCommand();

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -18,7 +18,8 @@ namespace JRunner.Panels
         // -a nohdd
         // -a nohdmiwait
         // -a nolan
-        // -r WB/WB4G/13182/ELPIS
+        // -r WB/WB4G/13182
+        // -r ELPIS
 
         public XeBuildPanel()
         {
@@ -872,11 +873,11 @@ namespace JRunner.Panels
             // Don't do it twice
             if (!chkWB4G.Checked && chkWB.Checked)
             {
-                updateWBAndElpis();
+                updateWB();
             }
             else if (!chkWB.Checked && !chkWB4G.Checked)
             {
-                updateWBAndElpis();
+                updateWB();
             }
         }
 
@@ -891,7 +892,7 @@ namespace JRunner.Panels
                 Console.WriteLine("Elpis CB_B deselected");
             }
 
-            updateWBAndElpis();
+            updateElpis();
         }
 
         private void chkWB4G_CheckedChanged(object sender, EventArgs e)
@@ -910,20 +911,28 @@ namespace JRunner.Panels
             // Don't do it twice
             if (!chkWB.Checked && chkWB4G.Checked)
             {
-                updateWBAndElpis();
+                updateWB();
             }
             else if (!chkWB.Checked && !chkWB4G.Checked)
             {
-                updateWBAndElpis();
+                updateWB();
             }
         }
 
-        private void updateWBAndElpis()
+        private void updateWB()
         {
             if (chkWB.Checked) patches[7] = "-r WB";
             else if (chkWB4G.Checked) patches[7] = "-r WB4G";
             else if (chkElpis.Checked) patches[7] = "-r ELPIS";
             else patches[7] = "";
+
+            updateCommand();
+        }
+
+        private void updateElpis()
+        {
+            if (chkElpis.Checked) patches[8] = "-r ELPIS";
+            else patches[8] = "";
 
             updateCommand();
         }
@@ -1711,6 +1720,8 @@ namespace JRunner.Panels
             RegexOptions options = RegexOptions.None;
             Regex regex = new Regex(@"[ ]{2,}", options);
             c = regex.Replace(c, @" ");
+
+            Console.WriteLine("command: {0}", c);
         }
 
         private void txtMBname_TextChanged(object sender, EventArgs e)

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -11,14 +11,14 @@ namespace JRunner.Panels
     public partial class XeBuildPanel : UserControl
     {
         List<CB> cbList;
-        List<string> patches = new List<string>(new string[8]);
+        List<string> patches = new List<string>(new string[9]);
         // -a nofcrt
         // -a noSShdd
         // -a nointmu
         // -a nohdd
         // -a nohdmiwait
         // -a nolan
-        // -r WB/WB4G/13182
+        // -r WB/WB4G/13182/ELPIS
 
         public XeBuildPanel()
         {
@@ -872,11 +872,11 @@ namespace JRunner.Panels
             // Don't do it twice
             if (!chkWB4G.Checked && chkWB.Checked)
             {
-                updateWB();
+                updateWBAndElpis();
             }
             else if (!chkWB.Checked && !chkWB4G.Checked)
             {
-                updateWB();
+                updateWBAndElpis();
             }
         }
 
@@ -890,6 +890,8 @@ namespace JRunner.Panels
             {
                 Console.WriteLine("Elpis CB_B deselected");
             }
+
+            updateWBAndElpis();
         }
 
         private void chkWB4G_CheckedChanged(object sender, EventArgs e)
@@ -908,18 +910,19 @@ namespace JRunner.Panels
             // Don't do it twice
             if (!chkWB.Checked && chkWB4G.Checked)
             {
-                updateWB();
+                updateWBAndElpis();
             }
             else if (!chkWB.Checked && !chkWB4G.Checked)
             {
-                updateWB();
+                updateWBAndElpis();
             }
         }
 
-        private void updateWB()
+        private void updateWBAndElpis()
         {
             if (chkWB.Checked) patches[7] = "-r WB";
             else if (chkWB4G.Checked) patches[7] = "-r WB4G";
+            else if (chkElpis.Checked) patches[7] = "-r ELPIS";
             else patches[7] = "";
 
             updateCommand();

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -1718,8 +1718,6 @@ namespace JRunner.Panels
             RegexOptions options = RegexOptions.None;
             Regex regex = new Regex(@"[ ]{2,}", options);
             c = regex.Replace(c, @" ");
-
-            Console.WriteLine("command: {0}", c);
         }
 
         private void txtMBname_TextChanged(object sender, EventArgs e)

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -319,7 +319,6 @@ namespace JRunner.Panels
             chkCR4.Visible = rbtnGlitch2.Checked || rbtnGlitch2m.Checked;
             chkSMCP.Visible = rbtnGlitch2.Checked || rbtnGlitch2m.Checked;
             chkRgh3.Visible = rbtnGlitch2.Checked || rbtnGlitch2m.Checked;
-            chkElpis.Visible = rbtnGlitch2.Checked;
             chkAudClamp.Visible = rbtnJtag.Checked;
             chkRJtag.Visible = rbtnJtag.Checked;
             chk0Fuse.Visible = rbtnDevGL.Checked;

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -153,12 +153,21 @@ namespace JRunner.Panels
             else if (chkWB4G.Checked) return 2;
             else return 0;
         }
+        public bool getElpisChecked()
+        {
+            return chkElpis.Checked;
+        }
 
         // Checkbox Setters
         public void setWBChecked(bool check)
         {
             if (check && (!chkWB.Enabled || !chkWB.Visible)) return;
             chkWB.Checked = check;
+        }
+        public void setElpisChecked(bool check)
+        {
+            if (check && (!chkElpis.Enabled || !chkElpis.Visible)) return;
+            chkElpis.Checked = check;
         }
         public void setCleanSMCChecked(bool check)
         {
@@ -256,10 +265,16 @@ namespace JRunner.Panels
 
                 if (txt.Contains("Xenon"))
                 {
+                    chkElpis.Enabled = true;
                     chkAudClamp.Checked = false;
                     chkAudClamp.Enabled = false;
                 }
-                else chkAudClamp.Enabled = true;
+                else
+                {
+                    chkElpis.Enabled = false;
+                    chkElpis.Checked = false;
+                    chkAudClamp.Enabled = true;
+                }
 
                 checkRgh3(txt);
             }));
@@ -303,15 +318,22 @@ namespace JRunner.Panels
             chkCR4.Visible = rbtnGlitch2.Checked || rbtnGlitch2m.Checked;
             chkSMCP.Visible = rbtnGlitch2.Checked || rbtnGlitch2m.Checked;
             chkRgh3.Visible = rbtnGlitch2.Checked || rbtnGlitch2m.Checked;
+            chkElpis.Visible = rbtnGlitch2.Checked;
             chkAudClamp.Visible = rbtnJtag.Checked;
             chkRJtag.Visible = rbtnJtag.Checked;
             chk0Fuse.Visible = rbtnDevGL.Checked;
+            chkElpis.Visible = rbtnGlitch2.Checked;
 
             checkWBXdkBuild();
             checkBigffs(variables.boardtype);
             checkDashSpecificPatches();
 
             if (!rbtnRetail.Checked && !rbtnGlitch.Checked && !rbtnGlitch2.Checked && !rbtnGlitch2m.Checked && !rbtnDevGL.Checked) chkCleanSMC.Checked = false;
+
+            if(!rbtnGlitch2.Checked)
+            {
+                chkElpis.Checked = false;
+            }
 
             if (!rbtnGlitch2.Checked && !rbtnGlitch2m.Checked)
             {
@@ -858,6 +880,18 @@ namespace JRunner.Panels
             }
         }
 
+        private void chkElpis_CheckedChanged(object sender, EventArgs e)
+        {
+            if (chkElpis.Checked)
+            {
+                Console.WriteLine("Elpis CB_B selected");
+            }
+            else if (!chkElpis.Checked) // Don't uselessly spam the console
+            {
+                Console.WriteLine("Elpis CB_B deselected");
+            }
+        }
+
         private void chkWB4G_CheckedChanged(object sender, EventArgs e)
         {
             if (chkWB4G.Checked)
@@ -1150,6 +1184,8 @@ namespace JRunner.Panels
             Rgh3Mhz.Visible = false;
             chkWB.Visible = false;
             chkWB4G.Enabled = false;
+            chkElpis.Enabled = false;
+            chkElpis.Visible = false;
             chkXdkBuild.Visible = false;
             chkRJtag.Visible = false;
             chkAudClamp.Visible = false;

--- a/J-Runner/Panels/XeBuildPanel.designer.cs
+++ b/J-Runner/Panels/XeBuildPanel.designer.cs
@@ -32,6 +32,7 @@
             this.groupBox7 = new System.Windows.Forms.GroupBox();
             this.MainTabs = new System.Windows.Forms.TabControl();
             this.tabXeBuild = new System.Windows.Forms.TabPage();
+            this.chkElpis = new System.Windows.Forms.CheckBox();
             this.Rgh3Label2 = new System.Windows.Forms.Label();
             this.Rgh3Label = new System.Windows.Forms.Label();
             this.Rgh3Mhz = new System.Windows.Forms.ComboBox();
@@ -143,6 +144,7 @@
             // tabXeBuild
             // 
             this.tabXeBuild.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.tabXeBuild.Controls.Add(this.chkElpis);
             this.tabXeBuild.Controls.Add(this.Rgh3Label2);
             this.tabXeBuild.Controls.Add(this.Rgh3Label);
             this.tabXeBuild.Controls.Add(this.Rgh3Mhz);
@@ -174,6 +176,19 @@
             this.tabXeBuild.Size = new System.Drawing.Size(323, 110);
             this.tabXeBuild.TabIndex = 0;
             this.tabXeBuild.Text = "Home";
+            // 
+            // chkElpis
+            // 
+            this.chkElpis.AutoSize = true;
+            this.chkElpis.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.chkElpis.Location = new System.Drawing.Point(229, 70);
+            this.chkElpis.Name = "chkElpis";
+            this.chkElpis.Size = new System.Drawing.Size(48, 17);
+            this.chkElpis.TabIndex = 100;
+            this.chkElpis.Text = "Elpis";
+            this.toolTip1.SetToolTip(this.chkElpis, "Xenon only, use 7378 CB_B for consoles with Elpis or Rhea GPUs");
+            this.chkElpis.UseVisualStyleBackColor = true;
+            this.chkElpis.CheckedChanged += new System.EventHandler(this.chkElpis_CheckedChanged);
             // 
             // Rgh3Label2
             // 
@@ -211,7 +226,7 @@
             // 
             this.chkRgh3.AutoSize = true;
             this.chkRgh3.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkRgh3.Location = new System.Drawing.Point(229, 63);
+            this.chkRgh3.Location = new System.Drawing.Point(229, 53);
             this.chkRgh3.Name = "chkRgh3";
             this.chkRgh3.Size = new System.Drawing.Size(56, 17);
             this.chkRgh3.TabIndex = 19;
@@ -237,7 +252,7 @@
             // chkCR4
             // 
             this.chkCR4.AutoSize = true;
-            this.chkCR4.Location = new System.Drawing.Point(229, 31);
+            this.chkCR4.Location = new System.Drawing.Point(229, 21);
             this.chkCR4.Name = "chkCR4";
             this.chkCR4.Size = new System.Drawing.Size(47, 17);
             this.chkCR4.TabIndex = 17;
@@ -304,7 +319,7 @@
             // 
             this.chkSMCP.AutoSize = true;
             this.chkSMCP.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.chkSMCP.Location = new System.Drawing.Point(229, 47);
+            this.chkSMCP.Location = new System.Drawing.Point(229, 37);
             this.chkSMCP.Name = "chkSMCP";
             this.chkSMCP.Size = new System.Drawing.Size(55, 17);
             this.chkSMCP.TabIndex = 18;
@@ -1119,5 +1134,6 @@
         private System.Windows.Forms.Button btnXEUpdate;
         private System.Windows.Forms.CheckBox chkXLBoth;
         private System.Windows.Forms.CheckBox chkCoronaKeyFix;
+        private System.Windows.Forms.CheckBox chkElpis;
     }
 }

--- a/J-Runner/Panels/XeBuildPanel.resx
+++ b/J-Runner/Panels/XeBuildPanel.resx
@@ -120,22 +120,10 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>293, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>293, 17</value>
-  </metadata>
-  <metadata name="dashBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>137, 17</value>
-  </metadata>
   <metadata name="dashBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>137, 17</value>
   </metadata>
   <metadata name="dashDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="dashDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>293, 17</value>
   </metadata>
 </root>


### PR DESCRIPTION
Borrows the hacked CB_B and ecc from wurthless-elektroniks (https://github.com/wurthless-elektroniks/elpiss), and adds support to J-Runner for building XeLL ecc's and xeBuild images. The new setting behaves similar to the corona WB_2K patch.

Credits were also added for the hacked CB_B

Requires the updated ecc (XENON_ELPIS.ecc), modified ini files (new falconbl_ELPIS sections with cbb_7378.bin), and new patches (patches_g2falcon_ELPIS.bin for each dash) from the the below zip file. They're the same as the files in the `elpiss` repo, just renamed.

[JrunnerElpisFiles.zip](https://github.com/user-attachments/files/22268526/JrunnerElpisFiles.zip)