### PR TITLE
Allow text in dashboard folder names

### DIFF
--- a/J-Runner/Classes/variables.cs
+++ b/J-Runner/Classes/variables.cs
@@ -299,7 +299,7 @@ namespace JRunner
         public static string FindFolder = "";
         public static bool rgh2 = false, xefinished = false;
         public static bool rgh1able = true;
-        public static int dashversion = 0;
+        public static string dashversion = "";
         public static bool copiedSMC = false;
         public static bool copiedXLDrive = false;
         public static bool foundXlUsb = false, foundXlHdd = false, foundXlBoth = false, foundUsbdSec = false, foundCoronaKeyFix = false;

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -26,7 +26,7 @@ namespace JRunner.Classes
         private bool success = false;
         private string _cpukey;
         private variables.hacktypes _ttype;
-        private int _dash;
+        private string _dash;
         private consoles _ctype;
         private bool _audclamp;
         private bool _CR4;
@@ -53,7 +53,7 @@ namespace JRunner.Classes
         private Nand.PrivateN _nand;
         private List<string> _patches;
 
-        public void loadvariables(string cpukey, variables.hacktypes ttype, int dash, consoles ctype, List<string> patches, Nand.PrivateN nand, bool altoptions, bool DLpatches, bool includeLaunch, bool audclamp, bool rjtag, bool cleansmc, bool cr4, bool smcp, bool rgh3, bool bigffs, bool zfuse, bool xdkbuild, bool xlusb, bool xlhdd, bool xlboth, bool usbdsec, bool coronakeyfix, bool fullDataClean)
+        public void loadvariables(string cpukey, variables.hacktypes ttype, string dash, consoles ctype, List<string> patches, Nand.PrivateN nand, bool altoptions, bool DLpatches, bool includeLaunch, bool audclamp, bool rjtag, bool cleansmc, bool cr4, bool smcp, bool rgh3, bool bigffs, bool zfuse, bool xdkbuild, bool xlusb, bool xlhdd, bool xlboth, bool usbdsec, bool coronakeyfix, bool fullDataClean)
         {
             this._cpukey = cpukey;
             this._ttype = ttype;
@@ -477,7 +477,7 @@ namespace JRunner.Classes
             if (string.IsNullOrEmpty(_cpukey)) return XebuildError.nocpukey;
 
             if (_ctype.ID == -1) return XebuildError.noconsole;
-            if (_dash == 0) return XebuildError.nodash;
+            if (_dash.Equals("")) return XebuildError.nodash;
             string ini = (variables.launchpath + @"\" + _dash + @"\_" + _ttype + ".ini");
 
             // Type overrides, check doSomeChecks() if changing
@@ -828,7 +828,7 @@ namespace JRunner.Classes
         ////////////////////////////////////////////////
 
 
-        public void Uloadvariables(int dash, variables.hacktypes ttype, List<string> patches, bool altoptions, bool nowrite, bool noava, bool clean, bool noreeb, bool DLpatches, bool includeLaunch)
+        public void Uloadvariables(string dash, variables.hacktypes ttype, List<string> patches, bool altoptions, bool nowrite, bool noava, bool clean, bool noreeb, bool DLpatches, bool includeLaunch)
         {
             this._dash = dash;
             this._ttype = ttype;
@@ -845,7 +845,7 @@ namespace JRunner.Classes
         public XebuildError createxebuild()
         {
             XebuildError result = XebuildError.none;
-            if (_dash == 0) result = XebuildError.nodash;
+            if (_dash.Equals("")) result = XebuildError.nodash;
             if (result != XebuildError.none) return result;
             moveOptions();
 

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -4871,6 +4871,10 @@ namespace JRunner
                 try
                 {
                     variables.dashes_all = new List<string>();
+
+                    // Regular expression to match either a folder containing just numbers,
+                    // or a folder beginning with a number, then an underscore, and then
+                    // any amount of alphanumeric or underscore characters
                     Regex regex = new Regex(@"^\d+(?:_[A-Za-z0-9_]+)?$");
 
                     foreach (string a in Directory.GetDirectories(Path.Combine(variables.currentdir, "xeBuild")))

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -4871,13 +4871,22 @@ namespace JRunner
                 try
                 {
                     variables.dashes_all = new List<string>();
-                    Regex regex = new Regex("^[0-9]+$");
+                    Regex regex = new Regex(@"^\d+(?:_[A-Za-z0-9_]+)?$");
 
                     foreach (string a in Directory.GetDirectories(Path.Combine(variables.currentdir, "xeBuild")))
                     {
                         if (regex.IsMatch(Path.GetFileNameWithoutExtension(a))) variables.dashes_all.Add(Path.GetFileNameWithoutExtension(a));
                     }
-                    variables.dashes_all.Sort((a, b) => Convert.ToInt32(a) - Convert.ToInt32(b));
+
+                    // Sort by the leading number of the dashboard folder
+                    variables.dashes_all.Sort((a, b) =>
+                    {
+                        int numA = int.TryParse(Regex.Match(a, @"^\d+").Value, out var nA) ? nA : 0;
+                        int numB = int.TryParse(Regex.Match(b, @"^\d+").Value, out var nB) ? nB : 0;
+
+                        return numA.CompareTo(numB);
+                    });
+
                     if (variables.debugMode) Console.WriteLine("Checking dashes");
                     foreach (string valueName in variables.dashes_all)
                     {
@@ -4901,18 +4910,16 @@ namespace JRunner
                 else if (xPanelCount == 2)
                 {
                     xPanel.getComboDash().SelectedIndex = 1;
-                    int n = 0;
-                    bool isNumeric = int.TryParse(xPanel.getComboDash().Text, out n);
-                    if (isNumeric) variables.dashversion = n;
+                    string n = xPanel.getComboDash().Text;
+                    if (char.IsDigit(n[0])) variables.dashversion = n;
                 }
                 else
                 {
                     if (variables.dashes_all.Contains(variables.preferredDash))
                     {
                         if (xPanelCount >= variables.dashes_all.IndexOf(variables.preferredDash)) xPanel.getComboDash().SelectedIndex = variables.dashes_all.IndexOf(variables.preferredDash) + 1;
-                        int n = 0;
-                        bool isNumeric = int.TryParse(xPanel.getComboDash().Text, out n);
-                        if (isNumeric) variables.dashversion = n;
+                        string n = xPanel.getComboDash().Text;
+                        if (char.IsDigit(n[0])) variables.dashversion = n;
                     }
                     else if (xPanelCount > 1) xPanel.BeginInvoke((Action)(() => xPanel.getComboDash().SelectedIndex = xPanelCount - 1));
                 }

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -388,7 +388,7 @@ namespace JRunner.Panels
             if (comboDash.SelectedIndex > 0)
             {
                 variables.preferredDash = comboDash.Text;
-                variables.dashversion = Convert.ToInt32(comboDash.Text);
+                variables.dashversion = comboDash.Text;
                 lblDash.Text = comboDash.Text;
             }
 
@@ -497,7 +497,7 @@ namespace JRunner.Panels
         private void checkGlitch2m(string board)
         {
             if (board == null) board = "None";
-            if (variables.dashversion == 17489 && File.Exists(variables.rootfolder + @"\xeBuild\17489\!XDKbuild Only!.txt"))
+            if (variables.dashversion.Equals("17489") && File.Exists(variables.rootfolder + @"\xeBuild\17489\!XDKbuild Only!.txt"))
             {
                 rbtnGlitch2m.Enabled = true;
             }
@@ -596,7 +596,7 @@ namespace JRunner.Panels
         bool chkWB4GEn = true;
         public void checkWBXdkBuild()
         {
-            if (rbtnGlitch2m.Checked && variables.dashversion == 17489 && File.Exists(variables.rootfolder + @"\xeBuild\17489\!XDKbuild Only!.txt"))
+            if (rbtnGlitch2m.Checked && variables.dashversion.Equals("17489") && File.Exists(variables.rootfolder + @"\xeBuild\17489\!XDKbuild Only!.txt"))
             {
                 chkWB.Visible = false;
                 chkWB.Checked = false;
@@ -1738,7 +1738,7 @@ namespace JRunner.Panels
             {
                 comboCB.Items.Clear();
                 cbList = new List<CB>();
-                if (variables.dashversion != 0)
+                if (!variables.dashversion.Equals(""))
                 {
                     string ini = (variables.launchpath + @"\" + variables.dashversion + @"\_retail.ini");
                     List<string> labels = new List<string>();

--- a/J-Runner/Panels/XeBuildPanel.designer.cs
+++ b/J-Runner/Panels/XeBuildPanel.designer.cs
@@ -411,7 +411,7 @@
             this.comboDash.FormattingEnabled = true;
             this.comboDash.Location = new System.Drawing.Point(16, 28);
             this.comboDash.Name = "comboDash";
-            this.comboDash.Size = new System.Drawing.Size(71, 21);
+            this.comboDash.Size = new System.Drawing.Size(96, 21);
             this.comboDash.TabIndex = 5;
             this.toolTip1.SetToolTip(this.comboDash, "Select the kernel/dashboard version used for XeBuild");
             this.comboDash.ValueMember = "Dash";


### PR DESCRIPTION
This PR allows for text in the dashboard folder names, and makes the dropdown box a little bit wider.

This allows for different folders with the same dashboard version but other customizations to be selected without making modifications to Jrunner.

e.g. I used this to make a JRunner compatible folder with the recently released RGLoader files for zero fuse consoles:

<img width="343" height="269" alt="image" src="https://github.com/user-attachments/assets/27652d24-af44-4ee5-8999-9089defb18c0" />