### PR TITLE
Show the XDKbuild checkbox when the DevGL radio button is selected

### DIFF
--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -596,7 +596,7 @@ namespace JRunner.Panels
         bool chkWB4GEn = true;
         public void checkWBXdkBuild()
         {
-            if (rbtnGlitch2m.Checked && variables.dashversion.Equals("17489") && File.Exists(variables.rootfolder + @"\xeBuild\17489\!XDKbuild Only!.txt"))
+            if ( (rbtnGlitch2m.Checked || rbtnDevGL.Checked) && variables.dashversion.Equals("17489") && File.Exists(variables.rootfolder + @"\xeBuild\17489\!XDKbuild Only!.txt"))
             {
                 chkWB.Visible = false;
                 chkWB.Checked = false;


### PR DESCRIPTION
Ensures the correct xeBuild command line options are used when building a 0fuse image for a BB console. Without this, it will build an image w/ the HDD redirection patches.

Before:
 
> xeBuild.exe -t devgl -c jasperbb -v -noenter -f 17489 -d data "Y:\Xbox 360\_Utilities\J-Runner-with-Extras\624456193905\updflash.bin


after:

> xeBuild.exe -t devgl -c jasperbigffs -i flash -v -noenter -f 17489 -d data "Y:\Xbox 360\_Utilities\J-Runner-with-Extras\624456193905\updflash.bin"