### PR TITLE
Additional XDKBuild fixes

### DIFF
--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -710,7 +710,7 @@ namespace JRunner.Classes
             pProcess.StartInfo.RedirectStandardInput = true;
             pProcess.StartInfo.RedirectStandardOutput = true;
             pProcess.StartInfo.CreateNoWindow = true;
-            if (!_xdkbuild && !_rgh3) pProcess.Exited += new EventHandler(xeExit);
+            if (!(_xdkbuild && _ttype != variables.hacktypes.devgl) && !_rgh3) pProcess.Exited += new EventHandler(xeExit);
             //pProcess.OutputDataReceived += new System.Diagnostics.DataReceivedEventHandler(DataReceived);
             //pProcess.Exited += new EventHandler(xe_Exited);
             //pProcess.OutputDataReceived += new System.Diagnostics.DataReceivedEventHandler(process_OutputDataReceived);
@@ -728,7 +728,7 @@ namespace JRunner.Classes
                         Console.WriteLine(e.Data);
                         if (e.Data != null && e.Data.Contains("image built")) {
                             success = true;
-                            if (!_xdkbuild && !_rgh3) variables.xefinished = true;
+                            if (!(_xdkbuild && _ttype != variables.hacktypes.devgl) && !_rgh3) variables.xefinished = true;
                         }
                     }
                 };
@@ -749,7 +749,7 @@ namespace JRunner.Classes
                         MainForm.mainForm.XDKbuild.create(boardtype, true);
                         MainForm.mainForm.rgh3Build.create(_ctype.Text, "00000000000000000000000000000000", true);
                     }
-                    else if (_xdkbuild) MainForm.mainForm.XDKbuild.create(boardtype);
+                    else if (_xdkbuild && _ttype != variables.hacktypes.devgl) MainForm.mainForm.XDKbuild.create(boardtype);
                     else if (_rgh3) MainForm.mainForm.rgh3Build.create(_ctype.Text, _cpukey, true);
                 }
             }
@@ -804,7 +804,7 @@ namespace JRunner.Classes
                         if (e.Data != null && e.Data.Contains("image built"))
                         {
                             success = true;
-                            if (!_xdkbuild && !_rgh3) variables.xefinished = true;
+                            if (!(_xdkbuild && _ttype != variables.hacktypes.devgl) && !_rgh3) variables.xefinished = true;
                         }
                     }
                 };

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2616,6 +2616,7 @@ namespace JRunner.Nand
                                   0x100000,   // XeLL-Only Image (Main XeLL)
                                   0xC0000,    // XeLL-Only Image (Backup XeLL)
                                   0xE0000,    // Unknown, but listed in libxenon updxell function
+                                  0xF0000,    // XeLL in the flashfs of XDKBuild and RGLoader images
                                   0xB80000 }; // Unknown, but listed in libxenon updxell function
 
             int blockType = 0;


### PR DESCRIPTION
Follow on to yesterday's patch to show the XDKbuild checkbox. That solved the xeBuild issue, where we weren't picking up the correct ini, but now we need to make sure we skip the XDKbuild conversion process.

XDKbuild isn't smart enough to notice that it's a DevGL image and clobbers the bootloaders in the DevGL image

In addition, the inject XeLL feature doesn't work because XeBuild puts XeLL at the beginning of the flash filesystem. The offset for XeLL has been added to the list. 