### PR TITLE
64mb DevGL support + some bonuses

### DIFF
--- a/J-Runner/Classes/variables.cs
+++ b/J-Runner/Classes/variables.cs
@@ -114,7 +114,7 @@ namespace JRunner
         public static bool logtofile = true;
         public static bool debugMode = false;
         public static bool generate = false;
-        public static bool checkfiles = true, deletefiles = false, extractfiles = false;
+        public static bool checkfiles = true, deletefiles = false, extractfiles = false, devkitnotdevgl = false;
         public static string preferredDash = latest_dashboard.ToString();
         public static bool DashlaunchE = false;
         public static bool LPTtiming = false;

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -671,6 +671,27 @@ namespace JRunner.Classes
             return result;
         }
 
+        private bool postBuildActionsAreRequired()
+        {
+            // So far, the following image types require post-build actions
+            // any others should be added here to prevent errors and file conflicts
+            //
+            // 1) XDKBuild when the hack type is NOT DevGL
+            // 2) Any type of RGH3 image
+            // 3) DevGL images for console types 3 (64mb Xenon), 13 (64mb Zephyr), and 14 (64mb Falcon)
+            //
+            if( (_xdkbuild && _ttype != variables.hacktypes.devgl) ||
+                _rgh3 ||
+                (_ttype == variables.hacktypes.devgl && (_ctype.ID == 7 || _ctype.ID == 13 || _ctype.ID == 14)) )
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
         public void build()
         {
             success = false;
@@ -678,17 +699,9 @@ namespace JRunner.Classes
             pProcess.StartInfo.FileName = variables.rootfolder + @"\xeBuild\xeBuild.exe";
             string arguments = "";
             string boardtype = _ctype.XeBuild;
+            string patchFileBaseName = "";
+            string patchFilePath = "";
 
-            if(variables.devkitnotdevgl && _ttype == variables.hacktypes.devgl)
-            {
-                Console.WriteLine("Using devkit image type for DevGL");
-                arguments = "-t " + variables.hacktypes.devkit;
-            }
-            else
-            {
-               arguments = "-t " + _ttype;
-            }
-                
             // Type overrides, check doSomeChecks() if changing
             if (_ttype == variables.hacktypes.glitch2 || _ttype == variables.hacktypes.glitch2m)
             {
@@ -720,6 +733,34 @@ namespace JRunner.Classes
                     boardtype = "jasper";
                     Console.WriteLine("Using Jasper type for Falcon");
                 }
+            }
+
+            if (_ttype == variables.hacktypes.devgl)
+            {
+                if (variables.devkitnotdevgl)
+                {
+                    Console.WriteLine("Using devkit image type instead of DevGL");
+                }
+                else if (_ctype.ID == 7 || _ctype.ID == 13 || _ctype.ID == 14)
+                {
+                    Console.WriteLine("Building 64mb DevGL image using XeBuild devkit mode");
+
+                    // To build a DevGL image for 64mb consoles successfully we need to
+                    // ensure the patch file exists so the post-build patch step can inject it
+                    patchFileBaseName = "patches_dev" + boardtype + ".bin";
+                    patchFilePath = variables.rootfolder + @"\xeBuild\" + _dash + "\\bin\\" + patchFileBaseName;
+                    if (!File.Exists(patchFilePath))
+                    {
+                        Console.WriteLine("Could not create 64mb DevGL image, " + patchFileBaseName + " for dashboard " + _dash + " missing.");
+                        return;
+                    }
+                }
+
+                arguments = "-t " + variables.hacktypes.devkit;
+            }
+            else
+            {
+                arguments = "-t " + _ttype;
             }
 
             if (_xdkbuild)
@@ -816,7 +857,7 @@ namespace JRunner.Classes
             pProcess.StartInfo.RedirectStandardInput = true;
             pProcess.StartInfo.RedirectStandardOutput = true;
             pProcess.StartInfo.CreateNoWindow = true;
-            if (!(_xdkbuild && _ttype != variables.hacktypes.devgl) && !_rgh3) pProcess.Exited += new EventHandler(xeExit);
+            if (!postBuildActionsAreRequired()) pProcess.Exited += new EventHandler(xeExit);
             //pProcess.OutputDataReceived += new System.Diagnostics.DataReceivedEventHandler(DataReceived);
             //pProcess.Exited += new EventHandler(xe_Exited);
             //pProcess.OutputDataReceived += new System.Diagnostics.DataReceivedEventHandler(process_OutputDataReceived);
@@ -834,7 +875,10 @@ namespace JRunner.Classes
                         Console.WriteLine(e.Data);
                         if (e.Data != null && e.Data.Contains("image built")) {
                             success = true;
-                            if (!(_xdkbuild && _ttype != variables.hacktypes.devgl) && !_rgh3) variables.xefinished = true;
+                            if (!postBuildActionsAreRequired())
+                            {
+                                variables.xefinished = true;
+                            }
                         }
                     }
                 };
@@ -850,13 +894,31 @@ namespace JRunner.Classes
 
                 if (success)
                 {
+                    // Any post-xeBuild actions are done here. Ensure the postBuildActionsAreRequired
+                    // function is updated if anything is added
+
                     if (_xdkbuild && _rgh3)
                     {
                         MainForm.mainForm.XDKbuild.create(boardtype, true);
                         MainForm.mainForm.rgh3Build.create(_ctype.Text, "00000000000000000000000000000000", true);
                     }
-                    else if (_xdkbuild && _ttype != variables.hacktypes.devgl) MainForm.mainForm.XDKbuild.create(boardtype);
-                    else if (_rgh3) MainForm.mainForm.rgh3Build.create(_ctype.Text, _cpukey, true);
+                    else if (_xdkbuild && _ttype != variables.hacktypes.devgl)
+                    {
+                        MainForm.mainForm.XDKbuild.create(boardtype);
+                    }
+                    else if (_rgh3)
+                    {
+                        MainForm.mainForm.rgh3Build.create(_ctype.Text, _cpukey, true);
+                    }
+                    else if (_ttype == variables.hacktypes.devgl && (_ctype.ID == 7 || _ctype.ID == 13 || _ctype.ID == 14))
+                    {
+                        // This is a 64mb DevGL image that we've got to patch... annoying af but that's xeBuild for us
+                        Nand.Nand.convertDevkitToDevGL(Path.Combine(variables.xefolder, variables.updflash),
+                                                        variables.cpukey,
+                                                        patchFilePath,
+                                                        true);
+                    }
+
                 }
             }
             catch (Exception objException)

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -249,11 +249,9 @@ namespace JRunner.Classes
                 Array.Resize(ref patchSectionBytes, (int)length);
                 s.Read(patchSectionBytes, 0, (int)length);
 
-                // If the patch address and length would make us run off the end of the buffer
-                // and the address + length isn't crazy (lets use 0xE0000, the address of the
-                // patch sets, as an arbitrary limit) we need to resize the bl to fit.
-                if(address + length > blData.Length &&
-                   address + length < 0xE0000 )
+                // If the patch address and length would make us run off 
+                // the end of the buffer we need to resize the buffer to fit.
+                if (address + length > blData.Length)
                 {
                     Array.Resize(ref blData, (int)(address + length));
                 }

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -396,7 +396,7 @@ namespace JRunner.Classes
             iniLines[iniSdEntryLine] = patchedIniString;
 
             // Write the BL to the dashboard folder
-            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), sdFileName), patchedBlData);
+            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), patchedSdFileName), patchedBlData);
 
             // Write the new ini file
             File.WriteAllLines(iniFilePath, iniLines);
@@ -1012,7 +1012,7 @@ namespace JRunner.Classes
                     }
 
                     // We also need to make sure the ini file exists, because we'll need to pre-patch the SD
-                    iniFilePath = variables.rootfolder + @"\xeBuild\" + _dash + "\\_devgl.ini";
+                    iniFilePath = variables.rootfolder + @"\xeBuild\" + _dash + "\\_devkit.ini";
                     if (!File.Exists(iniFilePath))
                     {
                         Console.WriteLine("Could not create 64mb DevGL image, _devgl.ini for dashboard " + _dash + " missing.");

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -150,6 +150,260 @@ namespace JRunner.Classes
             return xeBuildPatchData.Skip(khvPatchOffset).Take(khvPatchLength).ToArray();
         }
 
+        /// <summary>
+        /// Prepares bootloader data for CRC calculation in the same way xeBuild
+        /// does, e.g.
+        /// - File is truncated to the DWORD size at 0xC
+        /// - CB/CB_A/CB_B: fill with zeros from 0x10 for 0x30 bytes
+        /// - SC/CD/SD/CE/SE/CG: fill with zeros from 0x10 for 0x10 bytes
+        /// - CF: fill with zeros from 0x20 for 0x210 bytes
+        /// 
+        /// We don't need to look at the first byte for this, second
+        /// byte is enough to tell if it's 2BL, 3BL, etc.
+        /// 
+        /// </summary>
+        /// <param name="bl"></param>
+        /// <returns></returns>
+        private static byte[] prepBlForCrcCalc(byte[] bl)
+        {
+            int length = Oper.ByteArrayToInt(Oper.returnportion(bl, 0xC, 4));
+            if ( bl[1] == 0x42 ) //CB, SB
+            {
+                for (int i = 0x10; i < 0x40; i++) bl[i] = 0x0;
+            }
+            else if ( bl[1] == 0x43 || // SC
+                      bl[1] == 0x44 || // CD/SD
+                      bl[1] == 0x45 || // CE/SE
+                      bl[1] == 0x47 )  // CG
+            {
+                for (int i = 0x10; i < 0x20; i++) bl[i] = 0x0;
+            }
+            else if (bl[1] == 0x46) // CF
+            {
+                for (int i = 0x20; i < 0x230; i++) bl[i] = 0x0;
+            }
+            return Oper.returnportion(bl, 0, length);
+        }
+
+        /// <summary>
+        /// Calculates the CRC32 of a bootloader in the same way xeBuild
+        /// does for the purposes of integrity verification
+        /// </summary>
+        /// <param name="filename">Path to a BL file</param>
+        /// <returns></returns>
+        public static long calculateBlCrc(string filename)
+        {
+            return calculateBlCrc(File.ReadAllBytes(filename));
+        }
+
+        /// <summary>
+        /// Calculates the CRC32 of a bootloader in the same way xeBuild
+        /// does for the purposes of integrity verification
+        /// </summary>
+        /// <param name="blData">Byte buffer containing BL data</param>
+        /// <returns></returns>
+        public static long calculateBlCrc(byte[] blData)
+        {
+            byte[] processedBl = prepBlForCrcCalc(blData);
+
+            crc32 crc = new crc32();
+
+            return crc.CRC(processedBl);
+        }
+
+        public static byte[] patchBootloader(byte[] blData, byte[] patchData)
+        {
+            // xeBuild patch file format is the following:
+            //
+            // DWORD patch address
+            // DWORD patch size
+            // patch bytes
+            //
+            // repeated until an address of 0xFFFFFFFF is found
+            Stream s = new MemoryStream(patchData);
+
+            byte[] addressBytes = new byte[4];
+            UInt32 address = 0;
+
+            byte[] lengthBytes = new byte[4];
+            UInt32 length = 0;
+
+            byte[] patchSectionBytes = { };
+
+            while(0 != s.Read(addressBytes, 0, 4))
+            {
+                address = BitConverter.ToUInt32(addressBytes.Reverse().ToArray(), 0);
+
+                if (addressBytes[0] == 0xFF &&
+                    addressBytes[1] == 0xFF &&
+                    addressBytes[2] == 0xFF &&
+                    addressBytes[3] == 0xFF)
+                {
+                    // We've found the terminating 0xFF, stop looping
+                    break;
+                }
+
+                s.Read(lengthBytes, 0, 4);
+                length = BitConverter.ToUInt32(lengthBytes.Reverse().ToArray(), 0) * 4;
+
+                Array.Resize(ref patchSectionBytes, (int)length);
+                s.Read(patchSectionBytes, 0, (int)length);
+
+                // If the patch address and length would make us run off the end of the buffer
+                // and the address + length isn't crazy (lets use 0xE0000, the address of the
+                // patch sets, as an arbitrary limit) we need to resize the bl to fit.
+                if(address + length > blData.Length &&
+                   address + length < 0xE0000 )
+                {
+                    Array.Resize(ref blData, (int)(address + length));
+                }
+
+                Buffer.BlockCopy(patchSectionBytes, 0, blData, (int)address, (int)length);
+            }
+
+            // We've finished patching the bootloader. In case the patch made it an odd size
+            // extend it to the nearest multiple of 0x10 bytes.
+            int paddedLen = (blData.Length + 0xF) & ~0xF;
+
+            if(paddedLen > blData.Length)
+            {
+                Array.Resize(ref blData, paddedLen);
+            }
+
+            // Set the size of the bootloader at 0xC 
+            byte[] sizeBytes = BitConverter.GetBytes(paddedLen).Reverse().ToArray();
+            Buffer.BlockCopy(sizeBytes, 0, blData, 0xC, 4);
+
+            // We're all done!
+            return blData;
+        }
+
+        public static bool patchSdAndUpdateIniFile(string boardtype, string iniFilePath, string xeBuildPatchFilePath)
+        {
+            byte[] xeBuildPatchFileBytes = { };
+            byte[] xeBuildSdPatchSectionBytes = { };
+
+            try
+            {
+                xeBuildPatchFileBytes = File.ReadAllBytes(xeBuildPatchFilePath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("DevGL image creation error: couldn't read patch file " + xeBuildPatchFilePath);
+                if (variables.debugMode) Console.WriteLine(ex.ToString());
+                return false;
+            }
+
+            xeBuildSdPatchSectionBytes = return4blPatchSet(xeBuildPatchFileBytes);
+
+            // Grab the board type from the ini file
+            string[] iniLines = File.ReadAllLines(iniFilePath);
+            int iniSdEntryLine = 0;
+
+            for (int i = 0; i < iniLines.Length; i++)
+            {
+                // xeBuild ini format for devkit/devgl goes like this:
+                // [{boardtype}bl]
+                // SB
+                // SC
+                // CD/SD
+                // CE/SE
+                // CF
+                // CG
+                // 
+                // The 2nd index line returned *should* be our SD
+                if (iniLines[i] == "[" + boardtype + "bl]")
+                {
+                    iniSdEntryLine = i + 3;
+                }
+            }
+
+            if (iniSdEntryLine == 0)
+            {
+                Console.WriteLine("DevGL image creation error: couldn't find [" + boardtype + "bl] section in " + iniFilePath);
+                return false;
+            }
+
+            // Split it by the comma so we get the filename and CRC
+            string[] sdLine = iniLines[iniSdEntryLine].Split(',');
+
+            if (variables.debugMode) Console.WriteLine("SD expected pre-patching: " + sdLine);
+
+            string sdFileName = sdLine[0];
+            long sdIniCrc = Convert.ToInt64(sdLine[1], 16);
+
+            if(sdFileName.StartsWith("PATCH"))
+            {
+                Console.WriteLine("DevGL image creation error: can't patch an already-patched BL. Restore " + iniFilePath + " from a backup!");
+                return false;
+            }
+
+            // Now, search for the SD in one of two places:
+            // - In the same directory as the ini (likely here)
+            // - In the xeBuild\common folder (though for a devkit SD it's probably not there)
+            string sdFilePath = Path.Combine(Path.GetDirectoryName(iniFilePath), sdFileName);
+
+            if (!File.Exists(sdFilePath))
+            {
+                // Okay, it's not in the same directory as the ini
+                // Lets try the xeBuild common folder just in case
+                sdFilePath = Path.Combine(variables.rootfolder, @"xeBuild\common\" + sdFileName);
+
+                if (!File.Exists(sdFilePath))
+                {
+                    // It's not in one of the two places it could be.
+                    // We can't continue
+                    Console.WriteLine("DevGL image creation error: couldn't find " + sdFileName);
+                    return false;
+                }
+            }
+
+            // SD exists, calculate the CRC so we know we're starting from a known good binary
+            long sdFileCrc = calculateBlCrc(sdFilePath);
+
+            if (variables.debugMode) Console.WriteLine("SD calculated pre-patching: " + sdFileCrc.ToString("x"));
+
+            if (sdFileCrc != sdIniCrc)
+            {
+                Console.WriteLine("DevGL image creation error: " + sdFileName + " integrity check failed.");
+                Console.WriteLine("Calculated CRC: " + sdFileCrc.ToString("x"));
+                Console.WriteLine("Expected CRC: " + sdIniCrc.ToString("x"));
+                return false;
+            }
+
+            // We've got a good CRC, do the bootloader patch
+            byte[] patchedBlData = { };
+
+            try
+            {
+                patchedBlData = patchBootloader(File.ReadAllBytes(sdFilePath), xeBuildSdPatchSectionBytes);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("DevGL image creation error: couldn't patch " + sdFileName);
+                if (variables.debugMode) Console.WriteLine(ex.ToString());
+                return false;
+            }
+
+            // Now, recalculate the CRC and generate the string for the ini
+            string patchedSdFileName = "PATCH_" + sdFileName;
+            long patchedCRC = calculateBlCrc(patchedBlData);
+            string patchedIniString = patchedSdFileName + "," + patchedCRC.ToString("x");
+
+            if (variables.debugMode) Console.WriteLine("SD calculated post-patching: " + patchedIniString);
+
+            // Change the line in the ini file
+            iniLines[iniSdEntryLine] = patchedIniString;
+
+            // Write the BL to the dashboard folder
+            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), sdFileName), patchedBlData);
+
+            // Write the new ini file
+            File.WriteAllLines(iniFilePath, iniLines);
+
+            return true;
+        }
+
         public void loadvariables(string cpukey, variables.hacktypes ttype, string dash, consoles ctype, List<string> patches, Nand.PrivateN nand, bool altoptions, bool DLpatches, bool includeLaunch, bool audclamp, bool rjtag, bool cleansmc, bool cr4, bool smcp, bool rgh3, bool bigffs, bool zfuse, bool xdkbuild, bool xlusb, bool xlhdd, bool xlboth, bool usbdsec, bool coronakeyfix, bool fullDataClean)
         {
             this._cpukey = cpukey;
@@ -701,6 +955,8 @@ namespace JRunner.Classes
             string boardtype = _ctype.XeBuild;
             string patchFileBaseName = "";
             string patchFilePath = "";
+            string iniFilePath = "";
+            string[] iniFileContentsBackup = { };
 
             // Type overrides, check doSomeChecks() if changing
             if (_ttype == variables.hacktypes.glitch2 || _ttype == variables.hacktypes.glitch2m)
@@ -752,6 +1008,28 @@ namespace JRunner.Classes
                     if (!File.Exists(patchFilePath))
                     {
                         Console.WriteLine("Could not create 64mb DevGL image, " + patchFileBaseName + " for dashboard " + _dash + " missing.");
+                        return;
+                    }
+
+                    // We also need to make sure the ini file exists, because we'll need to pre-patch the SD
+                    iniFilePath = variables.rootfolder + @"\xeBuild\" + _dash + "\\_devgl.ini";
+                    if (!File.Exists(iniFilePath))
+                    {
+                        Console.WriteLine("Could not create 64mb DevGL image, _devgl.ini for dashboard " + _dash + " missing.");
+                        return;
+                    }
+
+                    // Take a backup of the ini file contents before we patch the ini and run XeBuild
+                    iniFileContentsBackup = File.ReadAllLines(iniFilePath);
+
+                    if(!patchSdAndUpdateIniFile(boardtype,iniFilePath,patchFilePath))
+                    {
+                        // If we failed to patch the SD and/or update the ini,
+                        // restore the ini contents from the backup and then bail
+                        File.WriteAllLines(iniFilePath, iniFileContentsBackup);
+
+                        variables.xefinished = true;
+                        MainForm.mainForm.xPanel.xeExitActual(false);
                         return;
                     }
                 }
@@ -912,6 +1190,9 @@ namespace JRunner.Classes
                     }
                     else if (_ttype == variables.hacktypes.devgl && (_ctype.ID == 7 || _ctype.ID == 13 || _ctype.ID == 14))
                     {
+                        // Now that XeBuild is done, we can restore the contents of the ini file
+                        File.WriteAllLines(iniFilePath, iniFileContentsBackup);
+
                         // This is a 64mb DevGL image that we've got to patch... annoying af but that's xeBuild for us
                         Nand.Nand.convertDevkitToDevGL(Path.Combine(variables.xefolder, variables.updflash),
                                                         variables.cpukey,

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -53,6 +53,103 @@ namespace JRunner.Classes
         private Nand.PrivateN _nand;
         private List<string> _patches;
 
+        // Methods for extracting the different sections of the input
+        // xeBuild patch data
+        //
+        // xeBuild patch files contain multiple sections, with a DWORD of
+        // 0xFFFFFFFF as the section terminator.
+        //
+        // 1st section is CB/CB_B/SB patches
+        //
+        // 2nd section is CD/SD patches
+        //
+        // 3rd section is the kernel patches, applied by the patching engine
+        // in the SD to the kernel. This is the SE in a devkit image, or the
+        // CE after CF/CG patching has taken place. XeBuild drops these as-is
+        // in to the NAND image 
+        //
+        // The terminating 0xFFFFFFFF is included in each patch section
+        //
+        public static int getLengthOfPatchSection(byte[] bytes, int offset)
+        {
+            // Stop at the last DWORD of the byte array, no point searching further
+            for (int i = offset; i < bytes.Length - 3; i++)
+            {
+                if (bytes[i] == 0xFF &&
+                    bytes[i + 1] == 0xFF &&
+                    bytes[i + 2] == 0xFF &&
+                    bytes[i + 3] == 0xFF)
+                {
+                    return i + 4 - offset;
+                }
+            }
+
+            return -1;
+        }
+
+        public static byte[] return2blPatchSet(byte[] xeBuildPatchData)
+        {
+            int sbPatchOffset = 0;
+            int sbPatchLength = getLengthOfPatchSection(xeBuildPatchData, sbPatchOffset);
+
+            if(sbPatchLength == -1)
+            {
+                return new byte[0];
+            }
+
+            return xeBuildPatchData.Take(sbPatchLength).ToArray();
+        }
+
+        public static byte[] return4blPatchSet(byte[] xeBuildPatchData)
+        {
+            int sbPatchOffset = 0;
+            int sbPatchLength = getLengthOfPatchSection(xeBuildPatchData, sbPatchOffset);
+
+            if (sbPatchLength == -1)
+            {
+                return new byte[0];
+            }
+
+            int sdPatchOffset = sbPatchOffset + sbPatchLength;
+            int sdPatchLength = getLengthOfPatchSection(xeBuildPatchData, sdPatchOffset);
+
+            if (sdPatchLength == -1)
+            {
+                return new byte[0];
+            }
+
+            return xeBuildPatchData.Skip(sdPatchOffset).Take(sdPatchLength).ToArray();
+        }
+
+        public static byte[] returnKernelHvPatchSet(byte[] xeBuildPatchData)
+        {
+            int sbPatchOffset = 0;
+            int sbPatchLength = getLengthOfPatchSection(xeBuildPatchData, sbPatchOffset);
+
+            if (sbPatchLength == -1)
+            {
+                return new byte[0];
+            }
+
+            int sdPatchOffset = sbPatchOffset + sbPatchLength;
+            int sdPatchLength = getLengthOfPatchSection(xeBuildPatchData, sdPatchOffset);
+
+            if (sdPatchLength == -1)
+            {
+                return new byte[0];
+            }
+
+            int khvPatchOffset = sdPatchOffset + sdPatchLength;
+            int khvPatchLength = getLengthOfPatchSection(xeBuildPatchData, khvPatchOffset);
+
+            if (khvPatchLength == -1)
+            {
+                return new byte[0];
+            }
+
+            return xeBuildPatchData.Skip(khvPatchOffset).Take(khvPatchLength).ToArray();
+        }
+
         public void loadvariables(string cpukey, variables.hacktypes ttype, string dash, consoles ctype, List<string> patches, Nand.PrivateN nand, bool altoptions, bool DLpatches, bool includeLaunch, bool audclamp, bool rjtag, bool cleansmc, bool cr4, bool smcp, bool rgh3, bool bigffs, bool zfuse, bool xdkbuild, bool xlusb, bool xlhdd, bool xlboth, bool usbdsec, bool coronakeyfix, bool fullDataClean)
         {
             this._cpukey = cpukey;

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -581,8 +581,17 @@ namespace JRunner.Classes
             pProcess.StartInfo.FileName = variables.rootfolder + @"\xeBuild\xeBuild.exe";
             string arguments = "";
             string boardtype = _ctype.XeBuild;
-            arguments = "-t " + _ttype;
 
+            if(variables.devkitnotdevgl && _ttype == variables.hacktypes.devgl)
+            {
+                Console.WriteLine("Using devkit image type for DevGL");
+                arguments = "-t " + variables.hacktypes.devkit;
+            }
+            else
+            {
+               arguments = "-t " + _ttype;
+            }
+                
             // Type overrides, check doSomeChecks() if changing
             if (_ttype == variables.hacktypes.glitch2 || _ttype == variables.hacktypes.glitch2m)
             {

--- a/J-Runner/Forms/CPUKeyGen.Designer.cs
+++ b/J-Runner/Forms/CPUKeyGen.Designer.cs
@@ -34,14 +34,15 @@ namespace JRunner.Forms
             this.label1 = new System.Windows.Forms.Label();
             this.btnGenKey = new System.Windows.Forms.Button();
             this.btnInsertKey = new System.Windows.Forms.Button();
+            this.btnValKey = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // txtGenKey
             // 
             this.txtGenKey.Location = new System.Drawing.Point(67, 9);
             this.txtGenKey.Margin = new System.Windows.Forms.Padding(2);
+            this.txtGenKey.MaxLength = 32;
             this.txtGenKey.Name = "txtGenKey";
-            this.txtGenKey.ReadOnly = true;
             this.txtGenKey.Size = new System.Drawing.Size(229, 20);
             this.txtGenKey.TabIndex = 0;
             this.txtGenKey.TextChanged += new System.EventHandler(this.txtGenKey_TextChanged);
@@ -70,7 +71,7 @@ namespace JRunner.Forms
             // btnInsertKey
             // 
             this.btnInsertKey.Enabled = false;
-            this.btnInsertKey.Location = new System.Drawing.Point(430, 8);
+            this.btnInsertKey.Location = new System.Drawing.Point(560, 8);
             this.btnInsertKey.Margin = new System.Windows.Forms.Padding(2);
             this.btnInsertKey.Name = "btnInsertKey";
             this.btnInsertKey.Size = new System.Drawing.Size(126, 22);
@@ -79,11 +80,23 @@ namespace JRunner.Forms
             this.btnInsertKey.UseVisualStyleBackColor = true;
             this.btnInsertKey.Click += new System.EventHandler(this.btnInsertKey_Click);
             // 
+            // btnValKey
+            // 
+            this.btnValKey.Location = new System.Drawing.Point(430, 8);
+            this.btnValKey.Margin = new System.Windows.Forms.Padding(2);
+            this.btnValKey.Name = "btnValKey";
+            this.btnValKey.Size = new System.Drawing.Size(126, 22);
+            this.btnValKey.TabIndex = 6;
+            this.btnValKey.Text = "Validate Key";
+            this.btnValKey.UseVisualStyleBackColor = true;
+            this.btnValKey.Click += new System.EventHandler(this.btnValKey_Click);
+            // 
             // CPUKeyGenGUI
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(564, 38);
+            this.ClientSize = new System.Drawing.Size(694, 38);
+            this.Controls.Add(this.btnValKey);
             this.Controls.Add(this.btnInsertKey);
             this.Controls.Add(this.btnGenKey);
             this.Controls.Add(this.label1);
@@ -107,5 +120,6 @@ namespace JRunner.Forms
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnGenKey;
         private System.Windows.Forms.Button btnInsertKey;
+        private System.Windows.Forms.Button btnValKey;
     }
 }

--- a/J-Runner/Forms/CPUKeyGen.cs
+++ b/J-Runner/Forms/CPUKeyGen.cs
@@ -14,7 +14,7 @@ namespace JRunner.Forms
 
         private void txtGenKey_TextChanged(object sender, EventArgs e)
         {
-            if (txtGenKey.TextLength > 0) btnInsertKey.Enabled = true;
+            if (txtGenKey.TextLength == 32) btnInsertKey.Enabled = true;
             else btnInsertKey.Enabled = false;
         }
 
@@ -28,6 +28,20 @@ namespace JRunner.Forms
         {
             MainForm.mainForm.updateCpuKeyText(txtGenKey.Text);
             this.Close();
+        }
+
+        private void btnValKey_Click(object sender, EventArgs e)
+        {
+            if(Nand.Nand.VerifyKey(Oper.StringToByteArray(txtGenKey.Text)))
+            {
+                MessageBox.Show("CPU Key is valid!", "Validate CPU Key", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                btnInsertKey.Enabled = true;
+            }
+            else
+            {
+                MessageBox.Show("CPU Key is invalid", "Validate CPU Key", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                btnInsertKey.Enabled = false;
+            }
         }
     }
 }

--- a/J-Runner/MainForm.Designer.cs
+++ b/J-Runner/MainForm.Designer.cs
@@ -154,6 +154,7 @@ namespace JRunner
             this.toolStripMenuItem11 = new System.Windows.Forms.ToolStripSeparator();
             this.loadGlitch2XeLLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.loadJTAGXeLLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.injectXeLLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem9 = new System.Windows.Forms.ToolStripSeparator();
             this.sMCConfigViewerToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.patchKVToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -168,7 +169,7 @@ namespace JRunner
             this.jRPBLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateJRPToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.keyDatabaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.injectXeLLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.patch64MbDevkitNANDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.groupBox8.SuspendLayout();
             this.getCpuKeyMenu.SuspendLayout();
             this.showWorkingFolderMenu.SuspendLayout();
@@ -1184,6 +1185,7 @@ namespace JRunner
             this.loadGlitch2XeLLToolStripMenuItem,
             this.loadJTAGXeLLToolStripMenuItem,
             this.injectXeLLToolStripMenuItem,
+            this.patch64MbDevkitNANDToolStripMenuItem,
             this.toolStripMenuItem9,
             this.sMCConfigViewerToolStripMenuItem1,
             this.patchKVToolStripMenuItem,
@@ -1254,6 +1256,13 @@ namespace JRunner
             this.loadJTAGXeLLToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
             this.loadJTAGXeLLToolStripMenuItem.Text = "Load JTAG XeLL...";
             this.loadJTAGXeLLToolStripMenuItem.Click += new System.EventHandler(this.loadJTAGXeLLToolStripMenuItem_Click);
+            // 
+            // injectXeLLToolStripMenuItem
+            // 
+            this.injectXeLLToolStripMenuItem.Name = "injectXeLLToolStripMenuItem";
+            this.injectXeLLToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.injectXeLLToolStripMenuItem.Text = "Inject XeLL";
+            this.injectXeLLToolStripMenuItem.Click += new System.EventHandler(this.injectXeLLToolStripMenuItem_Click);
             // 
             // toolStripMenuItem9
             // 
@@ -1366,12 +1375,12 @@ namespace JRunner
             this.keyDatabaseToolStripMenuItem.Text = "Key Database";
             this.keyDatabaseToolStripMenuItem.Click += new System.EventHandler(this.keyDatabaseToolStripMenuItem_Click);
             // 
-            // injectXeLLToolStripMenuItem
+            // patch64MbDevkitNANDToolStripMenuItem
             // 
-            this.injectXeLLToolStripMenuItem.Name = "injectXeLLToolStripMenuItem";
-            this.injectXeLLToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
-            this.injectXeLLToolStripMenuItem.Text = "Inject XeLL";
-            this.injectXeLLToolStripMenuItem.Click += new System.EventHandler(this.injectXeLLToolStripMenuItem_Click);
+            this.patch64MbDevkitNANDToolStripMenuItem.Name = "patch64MbDevkitNANDToolStripMenuItem";
+            this.patch64MbDevkitNANDToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+            this.patch64MbDevkitNANDToolStripMenuItem.Text = "Patch 64Mb Devkit NAND";
+            this.patch64MbDevkitNANDToolStripMenuItem.Click += new System.EventHandler(this.patch64MbDevkitNANDToolStripMenuItem_Click);
             // 
             // MainForm
             // 
@@ -1562,5 +1571,6 @@ namespace JRunner
         private ToolStripMenuItem nANDAlignmentToolStripMenuItem;
         private ToolStripMenuItem gB16MBToolStripMenuItem;
         private ToolStripMenuItem injectXeLLToolStripMenuItem;
+        private ToolStripMenuItem patch64MbDevkitNANDToolStripMenuItem;
     }
 }

--- a/J-Runner/MainForm.Designer.cs
+++ b/J-Runner/MainForm.Designer.cs
@@ -110,6 +110,7 @@ namespace JRunner
             this.writeFusionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.convertToRGH3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.convert64mbDevkitToDevGLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.checkSecdataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.CustomXeBuildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripSeparator();
@@ -169,7 +170,6 @@ namespace JRunner
             this.jRPBLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateJRPToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.keyDatabaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.patch64MbDevkitNANDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.groupBox8.SuspendLayout();
             this.getCpuKeyMenu.SuspendLayout();
             this.showWorkingFolderMenu.SuspendLayout();
@@ -845,6 +845,7 @@ namespace JRunner
             this.writeFusionToolStripMenuItem,
             this.toolStripMenuItem1,
             this.convertToRGH3ToolStripMenuItem,
+            this.convert64mbDevkitToDevGLToolStripMenuItem,
             this.checkSecdataToolStripMenuItem,
             this.CustomXeBuildMenuItem,
             this.toolStripMenuItem5,
@@ -890,6 +891,13 @@ namespace JRunner
             this.convertToRGH3ToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
             this.convertToRGH3ToolStripMenuItem.Text = "Convert to RGH3";
             this.convertToRGH3ToolStripMenuItem.Click += new System.EventHandler(this.convertToRGH3ToolStripMenuItem_Click);
+            // 
+            // convert64mbDevkitToDevGLToolStripMenuItem
+            // 
+            this.convert64mbDevkitToDevGLToolStripMenuItem.Name = "convert64mbDevkitToDevGLToolStripMenuItem";
+            this.convert64mbDevkitToDevGLToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
+            this.convert64mbDevkitToDevGLToolStripMenuItem.Text = "Convert 64mb Devkit to DevGL";
+            this.convert64mbDevkitToDevGLToolStripMenuItem.Click += new System.EventHandler(this.convert64mbDevkitToDevGLToolStripMenuItem_Click);
             // 
             // checkSecdataToolStripMenuItem
             // 
@@ -1185,7 +1193,6 @@ namespace JRunner
             this.loadGlitch2XeLLToolStripMenuItem,
             this.loadJTAGXeLLToolStripMenuItem,
             this.injectXeLLToolStripMenuItem,
-            this.patch64MbDevkitNANDToolStripMenuItem,
             this.toolStripMenuItem9,
             this.sMCConfigViewerToolStripMenuItem1,
             this.patchKVToolStripMenuItem,
@@ -1374,13 +1381,6 @@ namespace JRunner
             this.keyDatabaseToolStripMenuItem.Size = new System.Drawing.Size(105, 20);
             this.keyDatabaseToolStripMenuItem.Text = "Key Database";
             this.keyDatabaseToolStripMenuItem.Click += new System.EventHandler(this.keyDatabaseToolStripMenuItem_Click);
-            // 
-            // patch64MbDevkitNANDToolStripMenuItem
-            // 
-            this.patch64MbDevkitNANDToolStripMenuItem.Name = "patch64MbDevkitNANDToolStripMenuItem";
-            this.patch64MbDevkitNANDToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
-            this.patch64MbDevkitNANDToolStripMenuItem.Text = "Patch 64Mb Devkit NAND";
-            this.patch64MbDevkitNANDToolStripMenuItem.Click += new System.EventHandler(this.patch64MbDevkitNANDToolStripMenuItem_Click);
             // 
             // MainForm
             // 
@@ -1571,6 +1571,6 @@ namespace JRunner
         private ToolStripMenuItem nANDAlignmentToolStripMenuItem;
         private ToolStripMenuItem gB16MBToolStripMenuItem;
         private ToolStripMenuItem injectXeLLToolStripMenuItem;
-        private ToolStripMenuItem patch64MbDevkitNANDToolStripMenuItem;
+        private ToolStripMenuItem convert64mbDevkitToDevGLToolStripMenuItem;
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -5273,8 +5273,8 @@ namespace JRunner
 
 
 
-
         #endregion
+
 
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3218,8 +3218,6 @@ namespace JRunner
 
         private void convert64mbDevkitToDevGLToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            string xeBuildPatchFile;
-
             if (String.IsNullOrWhiteSpace(variables.filename1))
             {
                 Console.WriteLine("Devkit image conversion error: Please select a valid NAND image!");
@@ -3247,9 +3245,7 @@ namespace JRunner
                 return;
             }
 
-            xeBuildPatchFile = ofd.FileName;
-
-            Nand.Nand.convertDevkitToDevGL(variables.filename1, variables.cpukey, xeBuildPatchFile, false);
+            Nand.Nand.convertDevkitToDevGL(variables.filename1, variables.cpukey, ofd.FileName, false);
         }
 
         private void sMCConfigViewerToolStripMenuItem1_Click(object sender, EventArgs e)

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3097,7 +3097,11 @@ namespace JRunner
             if (variables.ctype.ID == -1) variables.ctype = callConsoleSelect(ConsoleSelect.Selected.All);
             if (variables.ctype.ID == -1) return;
 
-            if( (variables.ctype.ID == 7 || variables.ctype.ID == 13 || variables.ctype.ID == 14) &&
+            // xeBuild does not officially support creating images for 64mb xenon, zephyr, or falcon
+            // in retail/glitch/glitch2/devGL modes. HOWEVER, it does support devkit images, so if the
+            // selected hack type is DevGL, we can create and patch a devkit image with pre and post
+            // xeBuild patching steps
+            if ( (variables.ctype.ID == 7 || variables.ctype.ID == 13 || variables.ctype.ID == 14) &&
                  variables.ttyp != variables.hacktypes.devgl )
             {
                 if (MessageBox.Show("XeBuild does not support building 64MB images for Xenon, Zephyr, or Falcon\n\nContinuing will cause a 16MB image to be built\n\nDo you want to continue?", "Steep Hill Ahead", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -5275,6 +5275,6 @@ namespace JRunner
 
         #endregion
 
-
+        
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3134,7 +3134,8 @@ namespace JRunner
             if (variables.ctype.ID == -1) variables.ctype = callConsoleSelect(ConsoleSelect.Selected.All);
             if (variables.ctype.ID == -1) return;
 
-            if (variables.ctype.ID == 7 || variables.ctype.ID == 13 || variables.ctype.ID == 14)
+            if( (variables.ctype.ID == 7 || variables.ctype.ID == 13 || variables.ctype.ID == 14) &&
+                 variables.ttyp != variables.hacktypes.devgl )
             {
                 if (MessageBox.Show("XeBuild does not support building 64MB images for Xenon, Zephyr, or Falcon\n\nContinuing will cause a 16MB image to be built\n\nDo you want to continue?", "Steep Hill Ahead", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
                 {
@@ -3215,42 +3216,45 @@ namespace JRunner
             }
         }
 
-        private void patch64MbDevkitNANDToolStripMenuItem_Click(object sender, EventArgs e)
+        private void convert64mbDevkitToDevGLToolStripMenuItem_Click(object sender, EventArgs e)
         {
             string xeBuildPatchFile;
 
             if (String.IsNullOrWhiteSpace(variables.filename1))
             {
-                Console.WriteLine("Devkit 64mb patch error: Please select a valid NAND image!");
+                Console.WriteLine("Devkit image conversion error: Please select a valid NAND image!");
                 return;
             }
 
-            if( !Nand.Nand.VerifyKey(Oper.StringToByteArray(variables.cpukey)) ||
-                !nand.cpukeyverification(variables.cpukey) )
+            if (!Nand.Nand.VerifyKey(Oper.StringToByteArray(variables.cpukey)) ||
+                !nand.cpukeyverification(variables.cpukey))
             {
-                Console.WriteLine("Devkit 64mb patch error: Bad CPU Key!");
+                Console.WriteLine("Devkit image conversion error: Bad CPU Key!");
                 return;
             }
 
             OpenFileDialog ofd = new OpenFileDialog();
 
             ofd.FileName = "";
-            ofd.Filter = "xeBuild Jasper patch set (patches_devjasper.bin)|patches_devjasper.bin|All files (*.*)|*.*";
+            ofd.Filter = "xeBuild devkit patch set (patches_dev*.bin)|patches_dev*.bin|All files (*.*)|*.*";
             ofd.Title = "Select KHV patch";
             ofd.InitialDirectory = Path.Combine(variables.rootfolder, @"xeBuild\17489\bin");
             ofd.RestoreDirectory = false;
 
             if (ofd.ShowDialog() != DialogResult.OK)
             {
-                Console.WriteLine("Cancelled Devkit Image Patch");
+                Console.WriteLine("Cancelled Devkit image conversion");
                 return;
             }
 
             xeBuildPatchFile = ofd.FileName;
 
-            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, variables.cpukey, xeBuildPatchFile);
+            Nand.Nand.convertDevkitToDevGL(variables.filename1, variables.cpukey, xeBuildPatchFile, false);
+        }
 
-            nand_init();
+        private void patch64MbDevkitNANDToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+
         }
 
         private void sMCConfigViewerToolStripMenuItem1_Click(object sender, EventArgs e)
@@ -4268,19 +4272,6 @@ namespace JRunner
                     variables.debugMode = true;
                 }
             }
-            else if (e.KeyCode == Keys.F4 && e.Control && e.Alt)
-            {
-                if (!variables.devkitnotdevgl)
-                {
-                    variables.devkitnotdevgl = true;
-                    Console.WriteLine("Devkit instead of DevGL On");
-                }
-                else
-                {
-                    variables.devkitnotdevgl = false;
-                    Console.WriteLine("Devkit instead of DevGL Off");
-                }
-            }
             else if (e.Control && e.KeyCode == Keys.F3)
             {
                 if (!variables.extractfiles) { variables.extractfiles = true; Console.WriteLine("Extract Files On"); }
@@ -4324,6 +4315,16 @@ namespace JRunner
             }
             else if (e.KeyCode == Keys.F10)
             {
+                if (!variables.devkitnotdevgl)
+                {
+                    variables.devkitnotdevgl = true;
+                    Console.WriteLine("Devkit instead of DevGL On");
+                }
+                else
+                {
+                    variables.devkitnotdevgl = false;
+                    Console.WriteLine("Devkit instead of DevGL Off");
+                }
             }
             else if (e.KeyCode == Keys.F11)
             {
@@ -5281,8 +5282,8 @@ namespace JRunner
 
 
 
+
         #endregion
 
-        
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -1707,43 +1707,6 @@ namespace JRunner
             else return "";
         }
 
-        private long CRCbl(string filename)
-        {
-            crc32 crc = new crc32();
-            long hashData = 0;
-            if (File.Exists(filename))
-            {
-                byte[] fileb = File.ReadAllBytes(filename);
-                fileb = editbl(fileb);
-                hashData = crc.CRC(fileb);
-            }
-            return hashData;
-        }
-        private byte[] editbl(byte[] bl)
-        {
-            int length = Oper.ByteArrayToInt(Oper.returnportion(bl, 0xC, 4));
-            if (bl[0] == 0x43 && bl[1] == 0x42)
-            {
-                for (int i = 0x10; i < 0x40; i++) bl[i] = 0x0;
-            }
-            else if (bl[0] == 0x43 && bl[1] == 0x44)
-            {
-                for (int i = 0x10; i < 0x20; i++) bl[i] = 0x0;
-            }
-            else if (bl[0] == 0x43 && bl[1] == 0x45)
-            {
-                for (int i = 0x10; i < 0x20; i++) bl[i] = 0x0;
-            }
-            else if (bl[0] == 0x43 && bl[1] == 0x46)
-            {
-                for (int i = 0x20; i < 0x230; i++) bl[i] = 0x0;
-            }
-            else if (bl[0] == 0x43 && bl[1] == 0x47)
-            {
-                for (int i = 0x10; i < 0x20; i++) bl[i] = 0x0;
-            }
-            return Oper.returnportion(bl, 0, length);
-        }
         bool editblini(string file, string label, string cba, string cbb = "")
         {
             string bla;
@@ -1761,7 +1724,7 @@ namespace JRunner
                     Console.WriteLine("{0} not found. Insert it manually on the common folder", "cb_" + cba + ".bin");
                     return false;
                 }
-                bla = "cb_" + cba + ".bin," + CRCbl(Path.Combine(variables.rootfolder, "common", "cb_" + cba + ".bin")).ToString("x8");
+                bla = "cb_" + cba + ".bin," + Classes.xebuild.calculateBlCrc(Path.Combine(variables.rootfolder, "common", "cb_" + cba + ".bin")).ToString("x8");
                 blb = "none,00000000";
             }
             else
@@ -1784,8 +1747,8 @@ namespace JRunner
                     Console.WriteLine("{0} not found. Insert it manually on the common folder", "cbb_" + cba + ".bin");
                     return false;
                 }
-                bla = "cba_" + cba + ".bin," + CRCbl(Path.Combine(variables.rootfolder, "common", "cba_" + cba + ".bin")).ToString("x8");
-                blb = "cbb_" + cbb + ".bin," + CRCbl(Path.Combine(variables.rootfolder, "common", "cbb_" + cbb + ".bin")).ToString("x8");
+                bla = "cba_" + cba + ".bin," + Classes.xebuild.calculateBlCrc(Path.Combine(variables.rootfolder, "common", "cba_" + cba + ".bin")).ToString("x8");
+                blb = "cbb_" + cbb + ".bin," + Classes.xebuild.calculateBlCrc(Path.Combine(variables.rootfolder, "common", "cbb_" + cbb + ".bin")).ToString("x8");
             }
             Console.WriteLine("Editing File..");
             string[] lines = File.ReadAllLines(file);

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3252,11 +3252,6 @@ namespace JRunner
             Nand.Nand.convertDevkitToDevGL(variables.filename1, variables.cpukey, xeBuildPatchFile, false);
         }
 
-        private void patch64MbDevkitNANDToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-
-        }
-
         private void sMCConfigViewerToolStripMenuItem1_Click(object sender, EventArgs e)
         {
             SMCConfigEditor smcedit = new SMCConfigEditor();

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3216,7 +3216,7 @@ namespace JRunner
 
             khvPatchPath = ofd.FileName;
 
-            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, khvPatchPath);
+            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, variables.cpukey, khvPatchPath);
 
             nand_init();
         }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3184,11 +3184,18 @@ namespace JRunner
 
         private void patch64MbDevkitNANDToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            string khvPatchPath, vfusesPath;
+            string khvPatchPath;
 
-            if (String.IsNullOrEmpty(variables.filename1))
+            if (String.IsNullOrWhiteSpace(variables.filename1))
             {
-                MessageBox.Show("Please load a source NAND image before patching!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Console.WriteLine("Devkit 64mb patch error: Please select a valid NAND image!");
+                return;
+            }
+
+            if( !Nand.Nand.VerifyKey(Oper.StringToByteArray(variables.cpukey)) ||
+                !nand.cpukeyverification(variables.cpukey) )
+            {
+                Console.WriteLine("Devkit 64mb patch error: Bad CPU Key!");
                 return;
             }
 
@@ -3204,27 +3211,14 @@ namespace JRunner
             if (ofd.ShowDialog() != DialogResult.OK)
             {
                 Console.WriteLine("Cancelled Devkit Image Patch");
+                return;
             }
 
             khvPatchPath = ofd.FileName;
 
-            ofd.FileName = "";
-            ofd.Filter = "Virtual Fuses (fuses.bin)|fuses.bin|All files (*.*)|*.*";
-            ofd.Title = "Select Virtual Fuses";
-            ofd.InitialDirectory = Path.Combine(variables.rootfolder, @"xeBuild");
-            ofd.RestoreDirectory = false;
-
-            if (ofd.ShowDialog() != DialogResult.OK)
-            {
-                Console.WriteLine("Cancelled Devkit Image Patch");
-            }
-
-            vfusesPath = ofd.FileName;
-
-            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, khvPatchPath, vfusesPath);
+            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, khvPatchPath);
 
             nand_init();
-
         }
 
         private void sMCConfigViewerToolStripMenuItem1_Click(object sender, EventArgs e)

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -4197,6 +4197,19 @@ namespace JRunner
                     variables.debugMode = true;
                 }
             }
+            else if (e.KeyCode == Keys.F4 && e.Control && e.Alt)
+            {
+                if (!variables.devkitnotdevgl)
+                {
+                    variables.devkitnotdevgl = true;
+                    Console.WriteLine("Devkit instead of DevGL On");
+                }
+                else
+                {
+                    variables.devkitnotdevgl = false;
+                    Console.WriteLine("Devkit instead of DevGL Off");
+                }
+            }
             else if (e.Control && e.KeyCode == Keys.F3)
             {
                 if (!variables.extractfiles) { variables.extractfiles = true; Console.WriteLine("Extract Files On"); }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3217,7 +3217,7 @@ namespace JRunner
 
         private void patch64MbDevkitNANDToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            string khvPatchPath;
+            string xeBuildPatchFile;
 
             if (String.IsNullOrWhiteSpace(variables.filename1))
             {
@@ -3232,13 +3232,12 @@ namespace JRunner
                 return;
             }
 
-            // TODO is there a better InitialDirectory to pick?
             OpenFileDialog ofd = new OpenFileDialog();
 
             ofd.FileName = "";
-            ofd.Filter = "xeBuild KHV patch (*.bin)|*.bin|All files (*.*)|*.*";
+            ofd.Filter = "xeBuild Jasper patch set (patches_devjasper.bin)|patches_devjasper.bin|All files (*.*)|*.*";
             ofd.Title = "Select KHV patch";
-            ofd.InitialDirectory = Path.Combine(variables.rootfolder, @"xeBuild");
+            ofd.InitialDirectory = Path.Combine(variables.rootfolder, @"xeBuild\17489\bin");
             ofd.RestoreDirectory = false;
 
             if (ofd.ShowDialog() != DialogResult.OK)
@@ -3247,9 +3246,9 @@ namespace JRunner
                 return;
             }
 
-            khvPatchPath = ofd.FileName;
+            xeBuildPatchFile = ofd.FileName;
 
-            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, variables.cpukey, khvPatchPath);
+            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, variables.cpukey, xeBuildPatchFile);
 
             nand_init();
         }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3182,6 +3182,51 @@ namespace JRunner
             }
         }
 
+        private void patch64MbDevkitNANDToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            string khvPatchPath, vfusesPath;
+
+            if (String.IsNullOrEmpty(variables.filename1))
+            {
+                MessageBox.Show("Please load a source NAND image before patching!", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            // TODO is there a better InitialDirectory to pick?
+            OpenFileDialog ofd = new OpenFileDialog();
+
+            ofd.FileName = "";
+            ofd.Filter = "xeBuild KHV patch (*.bin)|*.bin|All files (*.*)|*.*";
+            ofd.Title = "Select KHV patch";
+            ofd.InitialDirectory = Path.Combine(variables.rootfolder, @"xeBuild");
+            ofd.RestoreDirectory = false;
+
+            if (ofd.ShowDialog() != DialogResult.OK)
+            {
+                Console.WriteLine("Cancelled Devkit Image Patch");
+            }
+
+            khvPatchPath = ofd.FileName;
+
+            ofd.FileName = "";
+            ofd.Filter = "Virtual Fuses (fuses.bin)|fuses.bin|All files (*.*)|*.*";
+            ofd.Title = "Select Virtual Fuses";
+            ofd.InitialDirectory = Path.Combine(variables.rootfolder, @"xeBuild");
+            ofd.RestoreDirectory = false;
+
+            if (ofd.ShowDialog() != DialogResult.OK)
+            {
+                Console.WriteLine("Cancelled Devkit Image Patch");
+            }
+
+            vfusesPath = ofd.FileName;
+
+            Nand.Nand.injectDevkitVfusesAndKhvPatches(variables.filename1, khvPatchPath, vfusesPath);
+
+            nand_init();
+
+        }
+
         private void sMCConfigViewerToolStripMenuItem1_Click(object sender, EventArgs e)
         {
             SMCConfigEditor smcedit = new SMCConfigEditor();

--- a/J-Runner/MainForm.resx
+++ b/J-Runner/MainForm.resx
@@ -120,6 +120,9 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>917, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>917, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnIPGetCPU.BtnImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/J-Runner/MainForm.resx
+++ b/J-Runner/MainForm.resx
@@ -120,9 +120,6 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>917, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>917, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnIPGetCPU.BtnImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2824,17 +2824,13 @@ namespace JRunner.Nand
             // logical pages are needed to store the patch data add 1 in case it's
             // not an even multiple of the page size, doesn't really matter if we
             // populate the buffer with an extra page since it's not at the end of NAND
-            byte[] nandPatchPages = flashData.Skip(patchOffsetPhys).Take(((vfuseAndKernelPatchData.Length / pagesz) + 1) * pagesz_phys).ToArray();
+            byte[] nandPatchPages = flashData.Take(patchOffsetPhys + (((vfuseAndKernelPatchData.Length / pagesz) + 1) * pagesz_phys)).ToArray();
 
             // remove the ECC, copy the vfuse + kernel patches, re-add ECC,
             // then copy the data back to the NAND data buffer 
             nandPatchPages = unecc(nandPatchPages);
             
-            Buffer.BlockCopy(vfuseAndKernelPatchData, 0, nandPatchPages, 0, vfuseAndKernelPatchData.Length);
-            
-            nandPatchPages = addecc_v2(nandPatchPages, true, patchOffsetPhys, blockType);
-
-            Buffer.BlockCopy(nandPatchPages, 0, flashData, patchOffsetPhys, nandPatchPages.Length);
+            Buffer.BlockCopy(vfuseAndKernelPatchData, 0, nandPatchPages, patchOffset, vfuseAndKernelPatchData.Length);
 
             //
             // Step 2: Patch the XeLL startup reason and zero-pair the SB 
@@ -2897,9 +2893,6 @@ namespace JRunner.Nand
             //
             #endregion
 
-            byte[] blPatchData = flashData.Take(patchOffsetPhys).ToArray();
-            blPatchData = unecc(blPatchData);
-
             // Step 2A: Patch the XeLL startup reason
             //
             // SD patches look at bytes 0x4E and 0x4F to determine when
@@ -2929,19 +2922,19 @@ namespace JRunner.Nand
             // WIREDXB3        = 0x5A
 
             // Set the powerup causes to 0x0 (ignore) and 0x12 (eject)
-            blPatchData[0x4E] = 0x0;
-            blPatchData[0x4F] = 0x12;
+            nandPatchPages[0x4E] = 0x0;
+            nandPatchPages[0x4F] = 0x12;
 
             //
             // Step 2b: Zero pair the SB
             //
 
             // Determine the offset and length of the SB
-            int sbOffset = BitConverter.ToInt32(blPatchData.Skip(0x8).Take(4).Reverse().ToArray(), 0);
-            int sbLength = BitConverter.ToInt32(blPatchData.Skip(sbOffset + 12).Take(4).Reverse().ToArray(), 0);
+            int sbOffset = BitConverter.ToInt32(nandPatchPages.Skip(0x8).Take(4).Reverse().ToArray(), 0);
+            int sbLength = BitConverter.ToInt32(nandPatchPages.Skip(sbOffset + 12).Take(4).Reverse().ToArray(), 0);
 
             // Extract the encrypted SB data
-            byte[] sb_crypt = blPatchData.Skip(sbOffset).Take(sbLength).ToArray();
+            byte[] sb_crypt = nandPatchPages.Skip(sbOffset).Take(sbLength).ToArray();
 
             // Decrypt the SB (it's encrypted the same way as a retail single CB or split CB_A)
             byte[] sb_decrypt = Nand.decrypt_CB(sb_crypt);
@@ -2961,11 +2954,11 @@ namespace JRunner.Nand
 
             // Re-encrypt the SB and place it back in the patch data
             sb_crypt = encrypt_CB(sb_decrypt, sb_nonce, ref sb_key);
-            Buffer.BlockCopy(sb_crypt, 0, blPatchData, sbOffset, sbLength);
+            Buffer.BlockCopy(sb_crypt, 0, nandPatchPages, sbOffset, sbLength);
 
             // Re-add ECC data and copy it over to the flash data buffer
-            blPatchData = addecc_v2(blPatchData,true,0,blockType);
-            Buffer.BlockCopy(blPatchData, 0, flashData, 0, blPatchData.Length);
+            nandPatchPages = addecc_v2(nandPatchPages,true,0,blockType);
+            Buffer.BlockCopy(nandPatchPages, 0, flashData, 0, nandPatchPages.Length);
 
             // So we've updated the flashData, write it back to disk!
             File.WriteAllBytes(flashFilePath, flashData);
@@ -3943,7 +3936,9 @@ namespace JRunner.Nand
                 val >>= 1;
             }
             val = ~val;
-            byte[] temp = Oper.StringToByteArray(((val << 6) & 0xFFFFFFFF).ToString("X"));
+
+            // TODO what are the implications of the X8? Why did i break this???
+            byte[] temp = Oper.StringToByteArray(((val << 6) & 0xFFFFFFFF).ToString("X8"));
             Array.Reverse(temp);
             for (int j = data.Length - 4; j != data.Length; j++) data[j] = temp[j - data.Length + 4];
             return data;

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -358,7 +358,6 @@ namespace JRunner.Nand
                     }
                     else if (id == 5)
                     {
-                        // TODO do i have to decrypt this to get useful data? Probably?
                         bl.CE = block_build;
                         if (variables.extractfiles) Oper.savefile(data, "output\\CE.bin");
                         ce_dec = Nand.decrypt_CE(data, cd_dec);

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2765,7 +2765,7 @@ namespace JRunner.Nand
             Console.WriteLine("");
         }
 
-        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string khvFilePath)
+        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string cpukey, string khvFilePath)
         {
             // This is where the XDKbuild patches expect the virtual fuses and kernel patches to be
             int patchOffset = 0xE0000;
@@ -2805,8 +2805,8 @@ namespace JRunner.Nand
             // bytes we use for making up the vfuses
             byte[] fuseline0 = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
             byte[] fuseline1_dev = { 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F };
-            byte[] fuseline3_4 = Oper.StringToByteArray(variables.cpukey.Substring(0, 16));
-            byte[] fuseline5_6 = Oper.StringToByteArray(variables.cpukey.Substring(16, 16));
+            byte[] fuseline3_4 = Oper.StringToByteArray(cpukey.Substring(0, 16));
+            byte[] fuseline5_6 = Oper.StringToByteArray(cpukey.Substring(16, 16));
 
             // Build the fake fuseset. Only need to set 0, 1, and the CPU key.
             // The others are left as zeros

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -232,7 +232,7 @@ namespace JRunner.Nand
 
         void unpack_base_image(byte[] image, bool bigblock)
         {
-            byte[] data, cb_dec = { }, cd_dec = { };
+            byte[] data, cb_dec = { }, cd_dec = { }, ce_dec = { };
             byte[] CB_A = null, CB_B = null; //SMC = null, CD = null, CE = null, Keyvault = null;
             bl.CB_A = 0; bl.CB_B = 0; bl.CD = 0; bl.CE = 0; bl.CF_0 = 0; bl.CG_0 = 0; bl.CF_1 = 0; bl.CG_1 = 0;
             uf.ldv_p0 = 0; uf.ldv_p1 = 0; uf.ldv_cb = 0; uf.pd_cb = ""; uf.pd_0 = ""; uf.pd_1 = "";
@@ -358,8 +358,11 @@ namespace JRunner.Nand
                     }
                     else if (id == 5)
                     {
+                        // TODO do i have to decrypt this to get useful data? Probably?
                         bl.CE = block_build;
                         if (variables.extractfiles) Oper.savefile(data, "output\\CE.bin");
+                        ce_dec = Nand.decrypt_CE(data, cd_dec);
+                        if (variables.extractfiles) Oper.savefile(data, "output\\CE_dec.bin");
                         //CE = data;
                     }
                     block_offset_b += block_size;
@@ -1554,6 +1557,12 @@ namespace JRunner.Nand
                 else finalimage[i] = imfordec[i - 0x20];
             }
             return finalimage;
+        }
+
+        public static byte[] decrypt_CE(byte[] CE, byte[] CD)
+        {
+            // CE is encrypted the exact same way the CD is
+            return decrypt_CD(CE, CD);
         }
 
         public static byte[] encrypt_CB_cpukey(byte[] image, byte[] CB_A_key, byte[] cpukey)
@@ -2826,6 +2835,11 @@ namespace JRunner.Nand
 
             kvData = unecc(kvData);
 
+            // TODO MUSTFIX
+            // We're currently assuming this is a zero CPU key. HOWEVER
+            // if you're running DevGL on an actual devkit or something
+            // and are using vfuses like a madman then it might be non-zero
+            // Or, when we zero-pair the SB
             kvData = decryptkv(kvData, keyZero);
 
             kvData = encryptkv_hmac(kvData, vCpuKey);
@@ -2835,7 +2849,7 @@ namespace JRunner.Nand
 
             Buffer.BlockCopy(kvData, 0, flashData, 0x4200, 0x4200);
 
-            // For our final trick, we're going to patch the startup reason values at 0x4E and 0x4F...
+            // For the second final trick, we're going to patch the startup reason values at 0x4E and 0x4F...
             // this is where the SD looks to know to boot XeLL with the eject button (or elsewhere)
             // and is what is normally patched by xeBuild on a non-devkit image.
 
@@ -2875,6 +2889,49 @@ namespace JRunner.Nand
 
             Buffer.BlockCopy(firstPage, 0, flashData, 0, firstPage.Length);
 
+
+            // For the last trick we need to zero-pair the SB. Notes for later:
+            //
+            // Based on
+            // https://github.com/InvoxiPlayGames/xenon-bltool/blob/master/include/xenon-bootloader.h#L58
+            // https://github.com/GoobyCorp/Xbox-360-Crypto/blob/master/build_lib.py
+            //
+            // Bytes 0x0 through 0x1F are not encrypted at all
+            //
+            // - Eyecatcher: 0x00, 0x01
+            // - Build Number: 0x02, 0x03
+            // - QFE???: 0x04, 0x05
+            // - Flags: 0x06, 0x07
+            // - Entrypoint: 0x08-0XB
+            // - BL size: 0xC-0xF
+            // - Nonce: 0x10-0x1F
+            //
+            // Decrypted CB/CB_B/SB:
+            //
+            // Goodies (all zero on a zero paired devkit CB):
+            // - Pairing Data: 0x20-0x22
+            // - LDV: 0x23
+            // - CB auth hash: 0x30-0x3f
+            //
+            // Signature:
+            // - Signature Padding: 0x40 - 0x11F
+            // - Signature (random byte?): 0x120
+            // - Signature salt: 0x121 - 0x12A
+            // - Signature Hash: 0x12B - 0x13E
+            // - Signature End: 0x13F
+            // 
+            // Remaining:
+            // - Globals???: 0x140 - 0x267
+            // - devkit public key RSA 2048: 0x268 - 0x376
+            // - SC key 0x378 - 0x387
+            // - SC salt 0x388 - 0x391 (XBOX_ROM_3)
+            // - SD salt 0x392 - 0x39B (XBOX_ROM_4)
+            // - Hash (CB_A has CB_B hash, CB_B has CD hash): 0x39C - 0x3AF
+            // - Remaining variables: 0x3B0
+            // - LDV???: 0x3B1
+            // - Remaining Variables: 0x3B2 - 0x3BF
+            //
+            // CB entrypoint is after this
 
             // So we've updated the flashData, write it back to disk!
             File.WriteAllBytes(flashFilePath, flashData);

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -3954,7 +3954,6 @@ namespace JRunner.Nand
             }
             val = ~val;
 
-            // TODO what are the implications of the X8? Why did i break this???
             // TODO what are the implications of the X8? Why did my code break this in the first place???
             byte[] temp = Oper.StringToByteArray(((val << 6) & 0xFFFFFFFF).ToString("X8"));
             Array.Reverse(temp);

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2617,7 +2617,8 @@ namespace JRunner.Nand
                                   0xC0000,    // XeLL-Only Image (Backup XeLL)
                                   0xE0000,    // Unknown, but listed in libxenon updxell function
                                   0xF0000,    // XeLL in the flashfs of XDKBuild and RGLoader images
-                                  0xB80000 }; // Unknown, but listed in libxenon updxell function
+                                  0xF4000,    // XeLL in the flashfs of Devkit images
+                                  0xB80000 }; // XeLL in the flashfs of BB Jasper and BB Trinity XDKBuild images
 
             int blockType = 0;
             bool flashHasEcc = false;
@@ -2754,6 +2755,133 @@ namespace JRunner.Nand
 
             Console.WriteLine("Successfully injected XeLL");
             Console.WriteLine("");
+        }
+
+        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string khvFilePath, string vfuseFilePath)
+        {
+            // This is where the XDKbuild patches expect the KHV and vfuses.bin to live
+            int patchOffset = 0xE0000;
+
+            byte[] flashData = File.ReadAllBytes(flashFilePath);
+            byte[] khvData = File.ReadAllBytes(khvFilePath);
+            byte[] vfusesData = File.ReadAllBytes(vfuseFilePath);
+
+            // Just for testing, we're going to assume that the image has ECC
+            int blockType = 0;
+            bool flashHasEcc = true;
+
+            int pagesz = 0x200;
+            int pagesz_phys = 0x210;
+
+            int patchPageNumber = patchOffset / pagesz;
+            int patchOffsetPhys = patchPageNumber * pagesz_phys;
+
+            Console.WriteLine("Physical Offset:" + patchOffsetPhys.ToString("x"));
+
+            // If the flash has ECC data, determine the block type so ECC data can be recalculated
+            if (flashHasEcc)
+            {
+                byte[] sparedata = flashData.Skip(0x4400).Take(0x10).ToArray();
+
+                // Block Types
+                // 0 = Small block NAND (XSB)
+                // 1 = Small block NAND on BB controller (PSB/KSB)
+                // 2 = Big block NAND on BB controller (PSB/KSB)
+                blockType = identifylayout(sparedata);
+            }
+
+            byte[] vfuseAndKernelPatchData = new byte[vfusesData.Length + khvData.Length];
+
+            // Copy the vfuse data first, then the KHV patch data
+            Buffer.BlockCopy(vfusesData, 0, vfuseAndKernelPatchData, 0, vfusesData.Length);
+            Buffer.BlockCopy(khvData,0, vfuseAndKernelPatchData, vfusesData.Length, khvData.Length);
+
+            // Get the physical pages we need to patch by finding out how many
+            // logical pages are needed to store the patch data add 1 in case it's
+            // not an even multiple of the page size, doesn't really matter if we
+            // populate the buffer with an extra page since it's not at the end of NAND
+            byte[] nandPatchPages = flashData.Skip(patchOffsetPhys).Take(((vfuseAndKernelPatchData.Length / pagesz) + 1) * pagesz_phys).ToArray();
+
+            // remove the ECC, copy the vfuse + kernel patches, re-add ECC,
+            // then copy the data back to the NAND data buffer 
+            nandPatchPages = unecc(nandPatchPages);
+            Buffer.BlockCopy(vfuseAndKernelPatchData, 0, nandPatchPages, 0, vfuseAndKernelPatchData.Length);
+            nandPatchPages = addecc_v2(nandPatchPages, true, patchOffsetPhys, blockType);
+
+            Buffer.BlockCopy(nandPatchPages, 0, flashData, patchOffsetPhys, nandPatchPages.Length);
+
+
+            // Now, let's re-encrypt the KV with whatever is in the fuses.bin because otherwise only XeLL will boot
+            // We're taking the value from fuseline 4 and 5 because it's contiguous. You could combine fuseline 3
+            // and 6, or some other combination too
+            byte[] vCpuKey = vfusesData.Skip(0x20).Take(0x10).ToArray();
+
+            // Theoretically we need to look at byte 0x6c in the NAND to find the KV offset and size but it doesn't really
+            // matter for a test. we're gonna pretent it's at physical offset 0x4200
+            // if (xenon_get_logical_nand_data(&ret, 0x6C, 4) == 0)
+
+            // We also assume that the KV is on a page boundary, and is an even multiple of a page size
+
+            byte[] kvData = flashData.Skip(0x4200).Take(0x4200).ToArray();
+
+            kvData = unecc(kvData);
+
+            kvData = decryptkv(kvData, keyZero);
+
+            kvData = encryptkv_hmac(kvData, vCpuKey);
+            //kvData = encryptkv(kvData, vCpuKey);
+
+            kvData = addecc_v2(kvData,true,0x4200,blockType);
+
+            Buffer.BlockCopy(kvData, 0, flashData, 0x4200, 0x4200);
+
+            // For our final trick, we're going to patch the startup reason values at 0x4E and 0x4F...
+            // this is where the SD looks to know to boot XeLL with the eject button (or elsewhere)
+            // and is what is normally patched by xeBuild on a non-devkit image.
+
+            // This is always in the first page, and we only need to take one page for patching
+            byte[] firstPage = flashData.Take(pagesz_phys).ToArray();
+
+            firstPage = unecc(firstPage);
+
+            /* Powerup cause values:
+             * 
+             * class PowerUpCause(Enum):
+                    POWER           = 0x11
+                    EJECT           = 0x12
+                    UNDOCUMENTED_15 = 0x15
+                    UNDOCUMENTED_16 = 0x16
+                    REMOPOWER       = 0x20
+                    UNDOCUMENTED_21 = 0x21
+                    REMOX           = 0x22
+                    WINBUTTON       = 0x24
+                    UNDOCUMENTED_30 = 0x30
+                    UNDOCUMENTED_31 = 0x31
+                    KIOSK           = 0x41
+                    WIRELESSX       = 0x55
+                    WIREDXF1        = 0x56
+                    WIREDXF2        = 0x57
+                    WIREDXB2        = 0x58
+                    WIREDXB1        = 0x59
+                    WIREDXB3        = 0x5A
+             */
+
+            // Patch the powerup causes to 0x0 (ignore)
+            // and 0x12 (eject)
+            firstPage[0x4E] = 0x0;
+            firstPage[0x4F] = 0x12;
+
+            firstPage = addecc_v2(firstPage, true, 0, blockType);
+
+            Buffer.BlockCopy(firstPage, 0, flashData, 0, firstPage.Length);
+
+
+            // So we've updated the flashData, write it back to disk!
+            File.WriteAllBytes(flashFilePath, flashData);
+
+            Console.WriteLine("Successfully injected Devkit Patch Data");
+            Console.WriteLine("");
+
         }
 
         private static byte[] CalculateCPUKeyECD(byte[] key)

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -20,6 +20,11 @@ namespace JRunner.Nand
         public int CG_0;
         public int CF_1;
         public int CG_1;
+
+        public string _2BL_magic;
+        public string _3BL_magic;
+        public string _4BL_magic;
+        public string _5BL_magic;
     }
     public struct SMCInfo
     {
@@ -236,6 +241,7 @@ namespace JRunner.Nand
             byte[] data, cb_dec = { }, sc_dec = { }, cd_dec = { }, ce_dec = { };
             byte[] CB_A = null, CB_B = null; //SMC = null, CD = null, CE = null, Keyvault = null;
             bl.CB_A = 0; bl.CB_B = 0; bl.CD = 0; bl.CE = 0; bl.CF_0 = 0; bl.CG_0 = 0; bl.CF_1 = 0; bl.CG_1 = 0;
+            bl._2BL_magic = "";bl._3BL_magic = "";bl._4BL_magic = "";bl._5BL_magic = "";
             uf.ldv_p0 = 0; uf.ldv_p1 = 0; uf.ldv_cb = 0; uf.pd_cb = ""; uf.pd_0 = ""; uf.pd_1 = "";
 
             if (Nand.rawecc(image)) Console.WriteLine("Image is raw");
@@ -306,6 +312,8 @@ namespace JRunner.Nand
                     if (block_offset_b + block_size <= image.Length) Buffer.BlockCopy(image, block_offset_b, data, 0, block_size);
                     if (id == 2)
                     {
+                        bl._2BL_magic = blIdString;
+
                         if (semi == 0)
                         {
                             bl.CB_A = block_build;
@@ -358,6 +366,7 @@ namespace JRunner.Nand
                     else if (id == 3)
                     {
                         bl.SC = block_build;
+                        bl._3BL_magic = blIdString;
                         if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + ".bin");
                         sc_dec = Nand.decrypt_SC(data);
                         if (variables.extractfiles) Oper.savefile(sc_dec, "output\\" + blIdString + "_dec.bin");
@@ -365,6 +374,7 @@ namespace JRunner.Nand
                     else if (id == 4)
                     {
                         bl.CD = block_build;
+                        bl._4BL_magic = blIdString;
                         if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + ".bin");
 
                         // Encryption of the dev 4BL is different than retail 4BL,
@@ -389,6 +399,7 @@ namespace JRunner.Nand
                     else if (id == 5)
                     {
                         bl.CE = block_build;
+                        bl._5BL_magic = blIdString;
                         if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + ".bin");
                         ce_dec = Nand.decrypt_CE(data, cd_dec);
                         if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + "_dec.bin");
@@ -2811,13 +2822,24 @@ namespace JRunner.Nand
             Console.WriteLine("");
         }
 
-        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string cpukey, string patchFilePath)
+        /// <summary>
+        /// Converts an input devkit image to a DevGL image by doing the following:
+        /// 1 - Patch in virtual fuses and the kernel/hypervisor patch set
+        /// 2 - Set the XeLL startup reason bytes
+        /// 3 - Zero-pair the SB
+        /// 4 - Fix the patch slot addresses for the SD patching engine
+        /// </summary>
+        /// <param name="flashFilePath">Flash image to be patched, result will be written back to the same file</param>
+        /// <param name="cpukey">CPU key for the image, needed to decrypt the KV</param>
+        /// <param name="patchFilePath">Path to the xeBuild patch file to use to patch the devkit image</param>
+        /// <param name="sequenced">True if this is part of a xeBuild operation, false otherwise</param>
+        public static void convertDevkitToDevGL(string flashFilePath, string cpukey, string patchFilePath, bool sequenced)
         {
             // This is where the XDKbuild patches expect the virtual fuses and kernel patches to be
             int patchOffset = 0xE0000;
 
-            byte[] flashData = { };File.ReadAllBytes(flashFilePath);
-            byte[] patchData = { }; File.ReadAllBytes(patchFilePath);
+            byte[] flashData = { };
+            byte[] patchData = { };
 
             try
             {
@@ -2825,8 +2847,14 @@ namespace JRunner.Nand
             }
             catch(Exception ex)
             {
-                Console.WriteLine("Devkit image patch error: couldn't read input flash image");
-                Console.WriteLine(ex.ToString());
+                Console.WriteLine("Devkit image conversion error: couldn't read input flash image");
+                if (variables.debugMode) Console.WriteLine(ex.ToString());
+
+                if (sequenced)
+                {
+                    variables.xefinished = true;
+                    MainForm.mainForm.xPanel.xeExitActual(false);
+                }
                 return;
             }
 
@@ -2835,7 +2863,13 @@ namespace JRunner.Nand
             // for 16mb/BB/non-ECC images
             if (flashData.Length != 69206016)
             {
-                Console.WriteLine("Devkit image patch error: Only 64mb images are supported.");
+                Console.WriteLine("Devkit image conversion error: Only 64mb images are supported.");
+
+                if (sequenced)
+                {
+                    variables.xefinished = true;
+                    MainForm.mainForm.xPanel.xeExitActual(false);
+                }
                 return;
             }
 
@@ -2845,8 +2879,14 @@ namespace JRunner.Nand
             }
             catch(Exception ex)
             {
-                Console.WriteLine("Devkit image patch error: couldn't read input patch data");
-                Console.WriteLine(ex.ToString());
+                Console.WriteLine("Devkit image conversion error: couldn't read input patch data");
+                if (variables.debugMode) Console.WriteLine(ex.ToString());
+
+                if (sequenced)
+                {
+                    variables.xefinished = true;
+                    MainForm.mainForm.xPanel.xeExitActual(false);
+                }
                 return;
             }
 
@@ -3027,13 +3067,29 @@ namespace JRunner.Nand
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Devkit image patch error: couldn't write modified flash image");
-                Console.WriteLine(ex.ToString());
+                Console.WriteLine("Devkit image conversion error: couldn't write modified flash image");
+                if (variables.debugMode) Console.WriteLine(ex.ToString());
+
+                if (sequenced)
+                {
+                    variables.xefinished = true;
+                    MainForm.mainForm.xPanel.xeExitActual(false);
+                }
                 return;
             }
 
             Console.WriteLine("Successfully converted Devkit image to DevGL");
             Console.WriteLine("");
+
+            if(sequenced)
+            {
+                variables.xefinished = true;
+                MainForm.mainForm.xPanel.xeExitActual();
+            }
+            else
+            {
+                MainForm.mainForm.nand_init();
+            }
         }
 
         private static byte[] CalculateCPUKeyECD(byte[] key)

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2956,6 +2956,10 @@ namespace JRunner.Nand
             sb_crypt = encrypt_CB(sb_decrypt, sb_nonce, ref sb_key);
             Buffer.BlockCopy(sb_crypt, 0, nandPatchPages, sbOffset, sbLength);
 
+            // I don't know what this does but we're going to make it match DevGL
+            // because the patching engine in the SD looks here for things
+            nandPatchPages[0x66] = 0x0;
+
             // Re-add ECC data and copy it over to the flash data buffer
             nandPatchPages = addecc_v2(nandPatchPages,true,0,blockType);
             Buffer.BlockCopy(nandPatchPages, 0, flashData, 0, nandPatchPages.Length);

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2625,7 +2625,7 @@ namespace JRunner.Nand
                                   0xC0000,    // XeLL-Only Image (Backup XeLL)
                                   0xE0000,    // Unknown, but listed in libxenon updxell function
                                   0xF0000,    // XeLL in the flashfs of XDKBuild and RGLoader images
-                                  0xF4000,    // XeLL in the flashfs of Devkit images
+                                  0xF4000,    // XeLL in the flashfs of 64mb Devkit images
                                   0xB80000 }; // XeLL in the flashfs of BB Jasper and BB Trinity XDKBuild images
 
             int blockType = 0;
@@ -2799,7 +2799,6 @@ namespace JRunner.Nand
             //
             // Step 1: Create vfuse patch and add kernel/hv patches
             //
-
             byte[] vfuseAndKernelPatchData = new byte[0x60 + khvData.Length];
             
             // bytes we use for making up the vfuses
@@ -2956,9 +2955,23 @@ namespace JRunner.Nand
             sb_crypt = encrypt_CB(sb_decrypt, sb_nonce, ref sb_key);
             Buffer.BlockCopy(sb_crypt, 0, nandPatchPages, sbOffset, sbLength);
 
-            // I don't know what this does but we're going to make it match DevGL
-            // because the patching engine in the SD looks here for things
-            nandPatchPages[0x66] = 0x0;
+            // The SD patching engine looks at two DWORDs, at 0x64 and 0x70
+            // to determine where to look for patches. To be able to find
+            // patches at 0xE0000, 0x64 and 0x70 need to be:
+            // 0x64 = 0x00 0x0D 0x00 0x00
+            // 0x70 = 0x00 0x01 0x00 0x00
+            //
+            // because 0xD0000 + 0x10000 = 0xE0000
+            //
+            nandPatchPages[0x64] = 0x00;
+            nandPatchPages[0x65] = 0x0D;
+            nandPatchPages[0x66] = 0x00;
+            nandPatchPages[0x67] = 0x00;
+
+            nandPatchPages[0x70] = 0x00;
+            nandPatchPages[0x71] = 0x01;
+            nandPatchPages[0x72] = 0x00;
+            nandPatchPages[0x73] = 0x00;
 
             // Re-add ECC data and copy it over to the flash data buffer
             nandPatchPages = addecc_v2(nandPatchPages,true,0,blockType);
@@ -3942,6 +3955,7 @@ namespace JRunner.Nand
             val = ~val;
 
             // TODO what are the implications of the X8? Why did i break this???
+            // TODO what are the implications of the X8? Why did my code break this in the first place???
             byte[] temp = Oper.StringToByteArray(((val << 6) & 0xFFFFFFFF).ToString("X8"));
             Array.Reverse(temp);
             for (int j = data.Length - 4; j != data.Length; j++) data[j] = temp[j - data.Length + 4];

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -13,6 +13,7 @@ namespace JRunner.Nand
     {
         public int CB_A;
         public int CB_B;
+        public int SC;
         public int CD;
         public int CE;
         public int CF_0;
@@ -232,7 +233,7 @@ namespace JRunner.Nand
 
         void unpack_base_image(byte[] image, bool bigblock)
         {
-            byte[] data, cb_dec = { }, cd_dec = { }, ce_dec = { };
+            byte[] data, cb_dec = { }, sc_dec = { }, cd_dec = { }, ce_dec = { };
             byte[] CB_A = null, CB_B = null; //SMC = null, CD = null, CE = null, Keyvault = null;
             bl.CB_A = 0; bl.CB_B = 0; bl.CD = 0; bl.CE = 0; bl.CF_0 = 0; bl.CG_0 = 0; bl.CF_1 = 0; bl.CG_1 = 0;
             uf.ldv_p0 = 0; uf.ldv_p1 = 0; uf.ldv_cb = 0; uf.pd_cb = ""; uf.pd_0 = ""; uf.pd_1 = "";
@@ -277,12 +278,18 @@ namespace JRunner.Nand
             {
                 int block = 0, block_size, id;
                 byte block_id;
+                bool isDevBl = false;
+                string blIdString = "";
                 int block_build;
                 byte[] block_build_b = new byte[2], block_size_b = new byte[4];
                 int block_offset_b = Convert.ToInt32(Oper.ByteArrayToString(block_offset), 16);
                 int semi = 0;
                 for (block = 0; block < 30; block++)
                 {
+                    // Dev BLs start with 0x53 (S)
+                    isDevBl = (image[block_offset_b] == 0x53);
+                    // Get the ID string of the BL (CB/CD/SB/SD/etc)
+                    blIdString = Encoding.ASCII.GetString(image.Skip(block_offset_b).Take(2).ToArray());
                     block_id = image[block_offset_b + 1];
                     Buffer.BlockCopy(image, block_offset_b + 2, block_build_b, 0, 2);
                     //block_build_b = returnportion(image, block_offset_b + 2, 2);
@@ -314,10 +321,10 @@ namespace JRunner.Nand
 
                         if (semi == 0)
                         {
-                            if (variables.extractfiles) Oper.savefile(data, "output\\CB_B.bin");
+                            if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + "_B.bin");
                             if (string.IsNullOrEmpty(variables.cpukey)) cb_dec = Nand.decrypt_CB_cpukey(CB_B, Nand.decrypt_CB(CB_A), Oper.StringToByteArray("00000000000000000000000000000000")); // It just needs something, doesn't matter that its not valid
                             else cb_dec = Nand.decrypt_CB_cpukey(CB_B, Nand.decrypt_CB(CB_A), Oper.StringToByteArray(variables.cpukey));
-                            if (variables.extractfiles) Oper.savefile(cb_dec, "output\\CB_B_dec.bin");
+                            if (variables.extractfiles) Oper.savefile(cb_dec, "output\\" + blIdString + "_B_dec.bin");
 
                             // Encrypted CB_Bs introduce problems parsing this data
                             if (cb_dec[0xA0] == 0 && cb_dec[0xA7] == 0 && cb_dec[0xAF] == 0)
@@ -348,20 +355,43 @@ namespace JRunner.Nand
                             if (variables.debugMode) Console.WriteLine("-Pairing Data: " + uf.pd_cb);
                         }
                     }
+                    else if (id == 3)
+                    {
+                        bl.SC = block_build;
+                        if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + ".bin");
+                        sc_dec = Nand.decrypt_SC(data);
+                        if (variables.extractfiles) Oper.savefile(sc_dec, "output\\" + blIdString + "_dec.bin");
+                    }
                     else if (id == 4)
                     {
                         bl.CD = block_build;
-                        if (variables.extractfiles) Oper.savefile(data, "output\\CD.bin");
-                        cd_dec = Nand.decrypt_CD(data, cb_dec);
-                        if (variables.extractfiles) Oper.savefile(cd_dec, "output\\CD_dec.bin");
+                        if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + ".bin");
+
+                        // Encryption of the dev 4BL is different than retail 4BL,
+                        // as it's based on the SC key rather than the SB key
+                        if (isDevBl)
+                        {
+                            // In case someone tries to open an XDKbuild image that hasn't been
+                            // patched, only try to decrypt the SD if the SC was decrypted OK
+                            if(sc_dec.Length > 0)
+                            {
+                                cd_dec = Nand.decrypt_SD(data, sc_dec);
+                                if (variables.extractfiles) Oper.savefile(cd_dec, "output\\SD_dec.bin");
+                            }
+                        }
+                        else
+                        {
+                            cd_dec = Nand.decrypt_CD(data, cb_dec);
+                            if (variables.extractfiles) Oper.savefile(cd_dec, "output\\CD_dec.bin");
+                        }
                         //CD = data;
                     }
                     else if (id == 5)
                     {
                         bl.CE = block_build;
-                        if (variables.extractfiles) Oper.savefile(data, "output\\CE.bin");
+                        if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + ".bin");
                         ce_dec = Nand.decrypt_CE(data, cd_dec);
-                        if (variables.extractfiles) Oper.savefile(data, "output\\CE_dec.bin");
+                        if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + "_dec.bin");
                         //CE = data;
                     }
                     block_offset_b += block_size;
@@ -1562,6 +1592,22 @@ namespace JRunner.Nand
         {
             // CE is encrypted the exact same way the CD is
             return decrypt_CD(CE, CD);
+        }
+
+        public static byte[] decrypt_SC(byte[] SC)
+        {
+            // This is decrypted the same way as CD, but with a zero key
+            // as input. So we don't have to reinvent the wheel, pass
+            // a blank byte array in to decrypt_CD
+            byte[] ZERO_KEY_SC = new byte[0x20];
+
+            return decrypt_CD(SC, ZERO_KEY_SC);
+        }
+
+        public static byte[] decrypt_SD(byte[] SD, byte[] SC)
+        {
+            // SD is decrypted the same way as CD, but with SC as input
+            return decrypt_CD(SD, SC);
         }
 
         public static byte[] encrypt_CB_cpukey(byte[] image, byte[] CB_A_key, byte[] cpukey)
@@ -2765,22 +2811,59 @@ namespace JRunner.Nand
             Console.WriteLine("");
         }
 
-        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string cpukey, string khvFilePath)
+        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string cpukey, string patchFilePath)
         {
             // This is where the XDKbuild patches expect the virtual fuses and kernel patches to be
             int patchOffset = 0xE0000;
 
-            byte[] flashData = File.ReadAllBytes(flashFilePath);
-            byte[] khvData = File.ReadAllBytes(khvFilePath);
+            byte[] flashData = { };File.ReadAllBytes(flashFilePath);
+            byte[] patchData = { }; File.ReadAllBytes(patchFilePath);
+
+            try
+            {
+                flashData = File.ReadAllBytes(flashFilePath);
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine("Devkit image patch error: couldn't read input flash image");
+                Console.WriteLine(ex.ToString());
+                return;
+            }
+
+            // Ensure we're working with a 64mb image, with ECC
+            // which is 69206016 bytes long. No patching is necessary
+            // for 16mb/BB/non-ECC images
+            if (flashData.Length != 69206016)
+            {
+                Console.WriteLine("Devkit image patch error: Only 64mb images are supported.");
+                return;
+            }
+
+            try
+            {
+                patchData = File.ReadAllBytes(patchFilePath);
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine("Devkit image patch error: couldn't read input patch data");
+                Console.WriteLine(ex.ToString());
+                return;
+            }
+
+            byte[] khvPatchData = Classes.xebuild.returnKernelHvPatchSet(patchData);
 
             // We're going to assume the image has ECC because this is only
             // really needed for 64mb consoles (Xenon/Zephyr/Falcon).
             int blockType = 0;
             bool flashHasEcc = true;
 
+            // Logical page size is always 0x200
+            // and the physical page size (with spare data) is always 0x210
             int pagesz = 0x200;
             int pagesz_phys = 0x210;
 
+            // Calculate the physical offset into the NAND image where we
+            // need to write the vfuses and kernel patch data
             int patchPageNumber = patchOffset / pagesz;
             int patchOffsetPhys = patchPageNumber * pagesz_phys;
 
@@ -2799,16 +2882,18 @@ namespace JRunner.Nand
             //
             // Step 1: Create vfuse patch and add kernel/hv patches
             //
-            byte[] vfuseAndKernelPatchData = new byte[0x60 + khvData.Length];
+            byte[] vfuseAndKernelPatchData = new byte[0x60 + khvPatchData.Length];
             
             // bytes we use for making up the vfuses
+            // Fuseline 0 and 1 are always the same for a devkit
+            // 3/4 and 5/6 make up the CPU key
+            // CB LDV and CF/CG LDV can be left blank
             byte[] fuseline0 = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
             byte[] fuseline1_dev = { 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F };
             byte[] fuseline3_4 = Oper.StringToByteArray(cpukey.Substring(0, 16));
             byte[] fuseline5_6 = Oper.StringToByteArray(cpukey.Substring(16, 16));
 
-            // Build the fake fuseset. Only need to set 0, 1, and the CPU key.
-            // The others are left as zeros
+            // Build the fake fuseset
             Buffer.BlockCopy(fuseline0,     0, vfuseAndKernelPatchData, 0   , 0x8);
             Buffer.BlockCopy(fuseline1_dev, 0, vfuseAndKernelPatchData, 0x8 , 0x8);
             Buffer.BlockCopy(fuseline3_4,   0, vfuseAndKernelPatchData, 0x18, 0x8);
@@ -2816,8 +2901,8 @@ namespace JRunner.Nand
             Buffer.BlockCopy(fuseline5_6,   0, vfuseAndKernelPatchData, 0x28, 0x8);
             Buffer.BlockCopy(fuseline5_6,   0, vfuseAndKernelPatchData, 0x30, 0x8);
 
-            // Copy over the kernel patches
-            Buffer.BlockCopy(khvData, 0, vfuseAndKernelPatchData, 0x60, khvData.Length);
+            // Build the vfuse/kernel patch section
+            Buffer.BlockCopy(khvPatchData, 0, vfuseAndKernelPatchData, 0x60, khvPatchData.Length);
 
             // Get the physical pages we need to patch by finding out how many
             // logical pages are needed to store the patch data add 1 in case it's
@@ -2825,75 +2910,18 @@ namespace JRunner.Nand
             // populate the buffer with an extra page since it's not at the end of NAND
             byte[] nandPatchPages = flashData.Take(patchOffsetPhys + (((vfuseAndKernelPatchData.Length / pagesz) + 1) * pagesz_phys)).ToArray();
 
-            // remove the ECC, copy the vfuse + kernel patches, re-add ECC,
-            // then copy the data back to the NAND data buffer 
+            // remove the ECC so we can copy our patch data to the logical addresses
             nandPatchPages = unecc(nandPatchPages);
             
+            //
+            // Step 1: copy over our vfuse/kernel patch data to patchOffset
+            //
             Buffer.BlockCopy(vfuseAndKernelPatchData, 0, nandPatchPages, patchOffset, vfuseAndKernelPatchData.Length);
 
             //
-            // Step 2: Patch the XeLL startup reason and zero-pair the SB 
+            // Step 2: Patch the XeLL startup reason
             //
 
-            #region cb notes
-            // For the last trick we need to zero-pair the SB. Notes for later:
-            //
-            // Based on
-            // https://github.com/InvoxiPlayGames/xenon-bltool/blob/master/include/xenon-bootloader.h#L58
-            // https://github.com/GoobyCorp/Xbox-360-Crypto/blob/master/build_lib.py
-            //
-            // Bytes 0x0 through 0x1F are not encrypted at all
-            //
-            // - Eyecatcher: 0x00, 0x01
-            // - Build Number: 0x02, 0x03
-            // - QFE???: 0x04, 0x05
-            // - Flags: 0x06, 0x07
-            // - Entrypoint: 0x08-0XB
-            // - BL size: 0xC-0xF
-            // - Nonce: 0x10-0x1F
-            //
-            // Decrypted CB/CB_B/SB:
-            //
-            // Goodies (all zero on a zero paired devkit CB):
-            // - Pairing Data: 0x20-0x22
-            // - LDV: 0x23
-            // - CB auth hash: 0x30-0x3f
-            //
-            // Signature:
-            // - Signature Padding: 0x40 - 0x11F
-            // - Signature (random byte?): 0x120
-            // - Signature salt: 0x121 - 0x12A
-            // - Signature Hash: 0x12B - 0x13E
-            // - Signature End: 0x13F
-            // 
-            // Remaining:
-            // - Globals???: 0x140 - 0x267
-            // - devkit public key RSA 2048: 0x268 - 0x376
-            // - SC key 0x378 - 0x387
-            // - SC salt 0x388 - 0x391 (XBOX_ROM_3)
-            // - SD salt 0x392 - 0x39B (XBOX_ROM_4)
-            // - Hash (CB_A has CB_B hash, CB_B has CD hash): 0x39C - 0x3AF
-            // - Remaining variables: 0x3B0
-            // - LDV???: 0x3B1
-            // - Remaining Variables: 0x3B2 - 0x3BF
-            //
-            // CB entrypoint is after this
-            //
-            // Encryption of the SC and later stages are different compared
-            // to retail CB/CD encryption- SC uses a zero key and nonce
-            // and the SD depends on the SC key. e.g.
-            //
-            // sb_key = XeCryptHmacSha(XECRYPT_1BL_KEY, sb_nonce)
-            // sc_key = XeCryptHmacSha(ZERO_KEY, sc_nonce)
-            // sd_key = XeCryptHmacSha(sc_key, sd_nonce)
-            // sd_key = XeCryptHmacSha(sd_key, se_nonce)
-            // 
-            // So, we can decrypt and zeropair the SB without touching later stages
-            //
-            #endregion
-
-            // Step 2A: Patch the XeLL startup reason
-            //
             // SD patches look at bytes 0x4E and 0x4F to determine when
             // to jump to XeLL rather than booting the kernel. This is
             // normally patched in by XeBuild but we have to do it manually
@@ -2925,8 +2953,19 @@ namespace JRunner.Nand
             nandPatchPages[0x4F] = 0x12;
 
             //
-            // Step 2b: Zero pair the SB
+            // Step 3: Zero pair the SB
             //
+
+            // Encryption of the SC and later stages are different compared
+            // to retail CB/CD encryption- SC uses a zero key and nonce
+            // and the SD depends on the SC key. e.g.
+            //
+            // sb_key = XeCryptHmacSha(XECRYPT_1BL_KEY, sb_nonce)
+            // sc_key = XeCryptHmacSha(ZERO_KEY, sc_nonce)
+            // sd_key = XeCryptHmacSha(sc_key, sd_nonce)
+            // sd_key = XeCryptHmacSha(sd_key, se_nonce)
+            // 
+            // So, we can decrypt and zeropair the SB without touching later stages
 
             // Determine the offset and length of the SB
             int sbOffset = BitConverter.ToInt32(nandPatchPages.Skip(0x8).Take(4).Reverse().ToArray(), 0);
@@ -2955,6 +2994,10 @@ namespace JRunner.Nand
             sb_crypt = encrypt_CB(sb_decrypt, sb_nonce, ref sb_key);
             Buffer.BlockCopy(sb_crypt, 0, nandPatchPages, sbOffset, sbLength);
 
+            //
+            // Step 4: Change the patch slot addresses at the beginning of NAND
+            //
+
             // The SD patching engine looks at two DWORDs, at 0x64 and 0x70
             // to determine where to look for patches. To be able to find
             // patches at 0xE0000, 0x64 and 0x70 need to be:
@@ -2977,12 +3020,20 @@ namespace JRunner.Nand
             nandPatchPages = addecc_v2(nandPatchPages,true,0,blockType);
             Buffer.BlockCopy(nandPatchPages, 0, flashData, 0, nandPatchPages.Length);
 
-            // So we've updated the flashData, write it back to disk!
-            File.WriteAllBytes(flashFilePath, flashData);
+            try
+            {
+                // So we've updated the flashData, write it back to disk!
+                File.WriteAllBytes(flashFilePath, flashData);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Devkit image patch error: couldn't write modified flash image");
+                Console.WriteLine(ex.ToString());
+                return;
+            }
 
-            Console.WriteLine("Successfully injected Devkit Patch Data");
+            Console.WriteLine("Successfully converted Devkit image to DevGL");
             Console.WriteLine("");
-
         }
 
         private static byte[] CalculateCPUKeyECD(byte[] key)

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -4061,7 +4061,9 @@ namespace JRunner.Nand
             }
             val = ~val;
 
-            // TODO what are the implications of the X8? Why did my code break this in the first place???
+            // For some values of val, the below stmt would return less than a 4 byte array
+            // (32-bit number). To ensure 4 bytes is always returned, "X8" replaces "X"
+            // in the ToString method below
             byte[] temp = Oper.StringToByteArray(((val << 6) & 0xFFFFFFFF).ToString("X8"));
             Array.Reverse(temp);
             for (int j = data.Length - 4; j != data.Length; j++) data[j] = temp[j - data.Length + 4];

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -11,6 +11,7 @@ namespace JRunner.Nand
 {
     public struct Bootloaders
     {
+        // BL Versions
         public int CB_A;
         public int CB_B;
         public int SC;
@@ -21,6 +22,7 @@ namespace JRunner.Nand
         public int CF_1;
         public int CG_1;
 
+        // BL Magic Strings (e.g. CB, SC, CD)
         public string _2BL_magic;
         public string _3BL_magic;
         public string _4BL_magic;
@@ -377,22 +379,22 @@ namespace JRunner.Nand
                         bl._4BL_magic = blIdString;
                         if (variables.extractfiles) Oper.savefile(data, "output\\" + blIdString + ".bin");
 
-                        // Encryption of the dev 4BL is different than retail 4BL,
-                        // as it's based on the SC key rather than the SB key
-                        if (isDevBl)
+                        // If there was a 3BL, the 4BL encryption is derived
+                        // from it rather than the 2BL
+                        if (bl.SC > 0)
                         {
                             // In case someone tries to open an XDKbuild image that hasn't been
                             // patched, only try to decrypt the SD if the SC was decrypted OK
                             if(sc_dec.Length > 0)
                             {
                                 cd_dec = Nand.decrypt_SD(data, sc_dec);
-                                if (variables.extractfiles) Oper.savefile(cd_dec, "output\\SD_dec.bin");
+                                if (variables.extractfiles) Oper.savefile(cd_dec, "output\\" + blIdString+ "_dec.bin");
                             }
                         }
                         else
                         {
                             cd_dec = Nand.decrypt_CD(data, cb_dec);
-                            if (variables.extractfiles) Oper.savefile(cd_dec, "output\\CD_dec.bin");
+                            if (variables.extractfiles) Oper.savefile(cd_dec, "output\\" + blIdString + "_dec.bin");
                         }
                         //CD = data;
                     }
@@ -3019,7 +3021,10 @@ namespace JRunner.Nand
 
             // Blow away all the pairing data, LDV, auth hash, etc
             // for a zero paired image and then re-encrypt everything
-            for(int i = 0x20; i<= 0x3F; i++)
+            // - Pairing Data: 0x20-0x22
+            // - LDV: 0x23
+            // - CB auth hash/per-box digest: 0x30-0x3f
+            for (int i = 0x20; i<= 0x3F; i++)
             {
                 sb_decrypt[i] = 0x0;
             }

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2765,16 +2765,16 @@ namespace JRunner.Nand
             Console.WriteLine("");
         }
 
-        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string khvFilePath, string vfuseFilePath)
+        public static void injectDevkitVfusesAndKhvPatches(string flashFilePath, string khvFilePath)
         {
-            // This is where the XDKbuild patches expect the KHV and vfuses.bin to live
+            // This is where the XDKbuild patches expect the virtual fuses and kernel patches to be
             int patchOffset = 0xE0000;
 
             byte[] flashData = File.ReadAllBytes(flashFilePath);
             byte[] khvData = File.ReadAllBytes(khvFilePath);
-            byte[] vfusesData = File.ReadAllBytes(vfuseFilePath);
 
-            // Just for testing, we're going to assume that the image has ECC
+            // We're going to assume the image has ECC because this is only
+            // really needed for 64mb consoles (Xenon/Zephyr/Falcon).
             int blockType = 0;
             bool flashHasEcc = true;
 
@@ -2783,8 +2783,6 @@ namespace JRunner.Nand
 
             int patchPageNumber = patchOffset / pagesz;
             int patchOffsetPhys = patchPageNumber * pagesz_phys;
-
-            Console.WriteLine("Physical Offset:" + patchOffsetPhys.ToString("x"));
 
             // If the flash has ECC data, determine the block type so ECC data can be recalculated
             if (flashHasEcc)
@@ -2798,11 +2796,29 @@ namespace JRunner.Nand
                 blockType = identifylayout(sparedata);
             }
 
-            byte[] vfuseAndKernelPatchData = new byte[vfusesData.Length + khvData.Length];
+            //
+            // Step 1: Create vfuse patch and add kernel/hv patches
+            //
 
-            // Copy the vfuse data first, then the KHV patch data
-            Buffer.BlockCopy(vfusesData, 0, vfuseAndKernelPatchData, 0, vfusesData.Length);
-            Buffer.BlockCopy(khvData,0, vfuseAndKernelPatchData, vfusesData.Length, khvData.Length);
+            byte[] vfuseAndKernelPatchData = new byte[0x60 + khvData.Length];
+            
+            // bytes we use for making up the vfuses
+            byte[] fuseline0 = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+            byte[] fuseline1_dev = { 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F };
+            byte[] fuseline3_4 = Oper.StringToByteArray(variables.cpukey.Substring(0, 16));
+            byte[] fuseline5_6 = Oper.StringToByteArray(variables.cpukey.Substring(16, 16));
+
+            // Build the fake fuseset. Only need to set 0, 1, and the CPU key.
+            // The others are left as zeros
+            Buffer.BlockCopy(fuseline0,     0, vfuseAndKernelPatchData, 0   , 0x8);
+            Buffer.BlockCopy(fuseline1_dev, 0, vfuseAndKernelPatchData, 0x8 , 0x8);
+            Buffer.BlockCopy(fuseline3_4,   0, vfuseAndKernelPatchData, 0x18, 0x8);
+            Buffer.BlockCopy(fuseline3_4,   0, vfuseAndKernelPatchData, 0x20, 0x8);
+            Buffer.BlockCopy(fuseline5_6,   0, vfuseAndKernelPatchData, 0x28, 0x8);
+            Buffer.BlockCopy(fuseline5_6,   0, vfuseAndKernelPatchData, 0x30, 0x8);
+
+            // Copy over the kernel patches
+            Buffer.BlockCopy(khvData, 0, vfuseAndKernelPatchData, 0x60, khvData.Length);
 
             // Get the physical pages we need to patch by finding out how many
             // logical pages are needed to store the patch data add 1 in case it's
@@ -2813,82 +2829,18 @@ namespace JRunner.Nand
             // remove the ECC, copy the vfuse + kernel patches, re-add ECC,
             // then copy the data back to the NAND data buffer 
             nandPatchPages = unecc(nandPatchPages);
+            
             Buffer.BlockCopy(vfuseAndKernelPatchData, 0, nandPatchPages, 0, vfuseAndKernelPatchData.Length);
+            
             nandPatchPages = addecc_v2(nandPatchPages, true, patchOffsetPhys, blockType);
 
             Buffer.BlockCopy(nandPatchPages, 0, flashData, patchOffsetPhys, nandPatchPages.Length);
 
+            //
+            // Step 2: Patch the XeLL startup reason and zero-pair the SB 
+            //
 
-            // Now, let's re-encrypt the KV with whatever is in the fuses.bin because otherwise only XeLL will boot
-            // We're taking the value from fuseline 4 and 5 because it's contiguous. You could combine fuseline 3
-            // and 6, or some other combination too
-            byte[] vCpuKey = vfusesData.Skip(0x20).Take(0x10).ToArray();
-
-            // Theoretically we need to look at byte 0x6c in the NAND to find the KV offset and size but it doesn't really
-            // matter for a test. we're gonna pretent it's at physical offset 0x4200
-            // if (xenon_get_logical_nand_data(&ret, 0x6C, 4) == 0)
-
-            // We also assume that the KV is on a page boundary, and is an even multiple of a page size
-
-            byte[] kvData = flashData.Skip(0x4200).Take(0x4200).ToArray();
-
-            kvData = unecc(kvData);
-
-            // TODO MUSTFIX
-            // We're currently assuming this is a zero CPU key. HOWEVER
-            // if you're running DevGL on an actual devkit or something
-            // and are using vfuses like a madman then it might be non-zero
-            // Or, when we zero-pair the SB
-            kvData = decryptkv(kvData, keyZero);
-
-            kvData = encryptkv_hmac(kvData, vCpuKey);
-            //kvData = encryptkv(kvData, vCpuKey);
-
-            kvData = addecc_v2(kvData,true,0x4200,blockType);
-
-            Buffer.BlockCopy(kvData, 0, flashData, 0x4200, 0x4200);
-
-            // For the second final trick, we're going to patch the startup reason values at 0x4E and 0x4F...
-            // this is where the SD looks to know to boot XeLL with the eject button (or elsewhere)
-            // and is what is normally patched by xeBuild on a non-devkit image.
-
-            // This is always in the first page, and we only need to take one page for patching
-            byte[] firstPage = flashData.Take(pagesz_phys).ToArray();
-
-            firstPage = unecc(firstPage);
-
-            /* Powerup cause values:
-             * 
-             * class PowerUpCause(Enum):
-                    POWER           = 0x11
-                    EJECT           = 0x12
-                    UNDOCUMENTED_15 = 0x15
-                    UNDOCUMENTED_16 = 0x16
-                    REMOPOWER       = 0x20
-                    UNDOCUMENTED_21 = 0x21
-                    REMOX           = 0x22
-                    WINBUTTON       = 0x24
-                    UNDOCUMENTED_30 = 0x30
-                    UNDOCUMENTED_31 = 0x31
-                    KIOSK           = 0x41
-                    WIRELESSX       = 0x55
-                    WIREDXF1        = 0x56
-                    WIREDXF2        = 0x57
-                    WIREDXB2        = 0x58
-                    WIREDXB1        = 0x59
-                    WIREDXB3        = 0x5A
-             */
-
-            // Patch the powerup causes to 0x0 (ignore)
-            // and 0x12 (eject)
-            firstPage[0x4E] = 0x0;
-            firstPage[0x4F] = 0x12;
-
-            firstPage = addecc_v2(firstPage, true, 0, blockType);
-
-            Buffer.BlockCopy(firstPage, 0, flashData, 0, firstPage.Length);
-
-
+            #region cb notes
             // For the last trick we need to zero-pair the SB. Notes for later:
             //
             // Based on
@@ -2931,6 +2883,89 @@ namespace JRunner.Nand
             // - Remaining Variables: 0x3B2 - 0x3BF
             //
             // CB entrypoint is after this
+            //
+            // Encryption of the SC and later stages are different compared
+            // to retail CB/CD encryption- SC uses a zero key and nonce
+            // and the SD depends on the SC key. e.g.
+            //
+            // sb_key = XeCryptHmacSha(XECRYPT_1BL_KEY, sb_nonce)
+            // sc_key = XeCryptHmacSha(ZERO_KEY, sc_nonce)
+            // sd_key = XeCryptHmacSha(sc_key, sd_nonce)
+            // sd_key = XeCryptHmacSha(sd_key, se_nonce)
+            // 
+            // So, we can decrypt and zeropair the SB without touching later stages
+            //
+            #endregion
+
+            byte[] blPatchData = flashData.Take(patchOffsetPhys).ToArray();
+            blPatchData = unecc(blPatchData);
+
+            // Step 2A: Patch the XeLL startup reason
+            //
+            // SD patches look at bytes 0x4E and 0x4F to determine when
+            // to jump to XeLL rather than booting the kernel. This is
+            // normally patched in by XeBuild but we have to do it manually
+            // for a devkit image. This is always located in the first page,
+            // so we can set it at the same time as zeropairing the SB
+            //
+            // Powerup cause values:
+            //
+            // POWER           = 0x11
+            // EJECT           = 0x12
+            // UNDOCUMENTED_15 = 0x15
+            // UNDOCUMENTED_16 = 0x16
+            // REMOPOWER       = 0x20
+            // UNDOCUMENTED_21 = 0x21
+            // REMOX           = 0x22
+            // WINBUTTON       = 0x24
+            // UNDOCUMENTED_30 = 0x30
+            // UNDOCUMENTED_31 = 0x31
+            // KIOSK           = 0x41
+            // WIRELESSX       = 0x55
+            // WIREDXF1        = 0x56
+            // WIREDXF2        = 0x57
+            // WIREDXB2        = 0x58
+            // WIREDXB1        = 0x59
+            // WIREDXB3        = 0x5A
+
+            // Set the powerup causes to 0x0 (ignore) and 0x12 (eject)
+            blPatchData[0x4E] = 0x0;
+            blPatchData[0x4F] = 0x12;
+
+            //
+            // Step 2b: Zero pair the SB
+            //
+
+            // Determine the offset and length of the SB
+            int sbOffset = BitConverter.ToInt32(blPatchData.Skip(0x8).Take(4).Reverse().ToArray(), 0);
+            int sbLength = BitConverter.ToInt32(blPatchData.Skip(sbOffset + 12).Take(4).Reverse().ToArray(), 0);
+
+            // Extract the encrypted SB data
+            byte[] sb_crypt = blPatchData.Skip(sbOffset).Take(sbLength).ToArray();
+
+            // Decrypt the SB (it's encrypted the same way as a retail single CB or split CB_A)
+            byte[] sb_decrypt = Nand.decrypt_CB(sb_crypt);
+
+            // Blow away all the pairing data, LDV, auth hash, etc
+            // for a zero paired image and then re-encrypt everything
+            for(int i = 0x20; i<= 0x3F; i++)
+            {
+                sb_decrypt[i] = 0x0;
+            }
+
+            // Use the same nonce from the encrypted SB
+            // sb_key is just to make encrypt_CB happy,
+            // we don't need it for any later stages
+            byte[] sb_nonce = sb_crypt.Skip(0x10).Take(0x10).ToArray();
+            byte[] sb_key = { };
+
+            // Re-encrypt the SB and place it back in the patch data
+            sb_crypt = encrypt_CB(sb_decrypt, sb_nonce, ref sb_key);
+            Buffer.BlockCopy(sb_crypt, 0, blPatchData, sbOffset, sbLength);
+
+            // Re-add ECC data and copy it over to the flash data buffer
+            blPatchData = addecc_v2(blPatchData,true,0,blockType);
+            Buffer.BlockCopy(blPatchData, 0, flashData, 0, blPatchData.Length);
 
             // So we've updated the flashData, write it back to disk!
             File.WriteAllBytes(flashFilePath, flashData);

--- a/J-Runner/Panels/NandInfo.Designer.cs
+++ b/J-Runner/Panels/NandInfo.Designer.cs
@@ -65,7 +65,6 @@
             this.textBox6BL_p0 = new System.Windows.Forms.TextBox();
             this.textBox7BL_p0 = new System.Windows.Forms.TextBox();
             this.label7bl_p0 = new System.Windows.Forms.Label();
-            this.label2bl = new System.Windows.Forms.Label();
             this.tabPageKV = new System.Windows.Forms.TabPage();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.label5 = new System.Windows.Forms.Label();
@@ -161,7 +160,6 @@
             this.groupBox1.Controls.Add(this.textBox6BL_p0);
             this.groupBox1.Controls.Add(this.textBox7BL_p0);
             this.groupBox1.Controls.Add(this.label7bl_p0);
-            this.groupBox1.Controls.Add(this.label2bl);
             this.groupBox1.Location = new System.Drawing.Point(4, 0);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(325, 269);
@@ -397,12 +395,12 @@
             // 
             // label2bla
             // 
-            this.label2bla.AutoSize = true;
-            this.label2bla.Location = new System.Drawing.Point(55, 50);
+            this.label2bla.Location = new System.Drawing.Point(55, 47);
             this.label2bla.Name = "label2bla";
-            this.label2bla.Size = new System.Drawing.Size(34, 13);
+            this.label2bla.Size = new System.Drawing.Size(34, 20);
             this.label2bla.TabIndex = 42;
             this.label2bla.Text = "CB_A";
+            this.label2bla.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // textBox4BL
             // 
@@ -417,12 +415,12 @@
             // 
             // label5bl
             // 
-            this.label5bl.AutoSize = true;
-            this.label5bl.Location = new System.Drawing.Point(68, 146);
+            this.label5bl.Location = new System.Drawing.Point(58, 142);
             this.label5bl.Name = "label5bl";
-            this.label5bl.Size = new System.Drawing.Size(21, 13);
+            this.label5bl.Size = new System.Drawing.Size(31, 20);
             this.label5bl.TabIndex = 38;
             this.label5bl.Text = "CE";
+            this.label5bl.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label6bl_p0
             // 
@@ -435,21 +433,21 @@
             // 
             // label4bl
             // 
-            this.label4bl.AutoSize = true;
-            this.label4bl.Location = new System.Drawing.Point(67, 114);
+            this.label4bl.Location = new System.Drawing.Point(58, 110);
             this.label4bl.Name = "label4bl";
-            this.label4bl.Size = new System.Drawing.Size(22, 13);
+            this.label4bl.Size = new System.Drawing.Size(31, 20);
             this.label4bl.TabIndex = 37;
             this.label4bl.Text = "CD";
+            this.label4bl.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label2blb
             // 
-            this.label2blb.AutoSize = true;
-            this.label2blb.Location = new System.Drawing.Point(55, 82);
+            this.label2blb.Location = new System.Drawing.Point(55, 78);
             this.label2blb.Name = "label2blb";
-            this.label2blb.Size = new System.Drawing.Size(34, 13);
+            this.label2blb.Size = new System.Drawing.Size(34, 20);
             this.label2blb.TabIndex = 41;
             this.label2blb.Text = "CB_B";
+            this.label2blb.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // textBox2BLb
             // 
@@ -514,15 +512,6 @@
             this.label7bl_p0.Size = new System.Drawing.Size(83, 13);
             this.label7bl_p0.TabIndex = 40;
             this.label7bl_p0.Text = "CG Patch Slot 0";
-            // 
-            // label2bl
-            // 
-            this.label2bl.AutoSize = true;
-            this.label2bl.Location = new System.Drawing.Point(68, 50);
-            this.label2bl.Name = "label2bl";
-            this.label2bl.Size = new System.Drawing.Size(21, 13);
-            this.label2bl.TabIndex = 29;
-            this.label2bl.Text = "CB";
             // 
             // tabPageKV
             // 
@@ -841,7 +830,6 @@
         private System.Windows.Forms.TextBox textBox6BL_p0;
         private System.Windows.Forms.TextBox textBox7BL_p0;
         private System.Windows.Forms.Label label7bl_p0;
-        private System.Windows.Forms.Label label2bl;
         private System.Windows.Forms.TabPage tabPageKV;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.Label lblfcrt;

--- a/J-Runner/Panels/NandInfo.cs
+++ b/J-Runner/Panels/NandInfo.cs
@@ -19,7 +19,6 @@ namespace JRunner.Panels
             InitializeComponent();
             lblfcrt.Visible = false;
             lblhashed.Visible = false;
-            label2bl.Visible = false;
             setNand(Nand);
         }
 
@@ -46,7 +45,6 @@ namespace JRunner.Panels
             textBox2BLb.Enabled = true;
             label2blb.Visible = true;
             label2bla.Visible = true;
-            label2bl.Visible = false;
 
             // KV Info
             btnConsoleId.Text = "View: Native";
@@ -74,14 +72,71 @@ namespace JRunner.Panels
             {
                 textBox2BLa.BeginInvoke(new Action(() => {
                     // Nand Info
-                    if (nand.bl.CB_A > 0) textBox2BLa.Text = nand.bl.CB_A.ToString();
-                    else textBox2BLa.Text = "";
-                    if (nand.bl.CB_B > 0) textBox2BLb.Text = nand.bl.CB_B.ToString();
-                    else textBox2BLb.Text = "";
-                    if (nand.bl.CD > 0) textBox4BL.Text = nand.bl.CD.ToString();
-                    else textBox4BL.Text = "";
-                    if (nand.bl.CE > 0) textBox5BL.Text = nand.bl.CE.ToString();
-                    else textBox5BL.Text = "";
+
+                    if (nand.bl.CB_A > 0)
+                    {
+                        textBox2BLa.Text = nand.bl.CB_A.ToString();
+                        label2bla.Text = nand.bl._2BL_magic;
+                    }
+                    else
+                    {
+                        label2bla.Text = "CB_A";
+                        textBox2BLa.Text = "";
+                    }
+
+                    if (nand.bl.CB_B > 0)
+                    {
+                        label2bla.Text = "CB_A";
+                        label2blb.Text = "CB_B";
+                        textBox2BLb.Text = nand.bl.CB_B.ToString();
+                        textBox2BLb.Enabled = true;
+                        label2blb.Visible = true;
+
+                        if (textBox2BLb.Text == "15432") textBoxCbType.Text = "RGH3";
+                        else textBoxCbType.Text = "Split";
+                    }
+                    else
+                    {
+                        if (nand.bl.SC > 0)
+                        {
+                            label2blb.Text = nand.bl._3BL_magic;
+                            textBox2BLb.Text = nand.bl.SC.ToString();
+                            label2blb.Visible = true;
+                            textBox2BLb.Enabled = true;
+                        }
+                        else
+                        {
+                            label2blb.Text = "CB_B";
+                            textBox2BLb.Text = "";
+                            label2blb.Visible = false;
+                            textBox2BLb.Enabled = false;
+                        }
+                            
+                        textBoxCbType.Text = "Single";
+                    }
+
+                    if (nand.bl.CD > 0)
+                    {
+                        label4bl.Text = nand.bl._4BL_magic;
+                        textBox4BL.Text = nand.bl.CD.ToString();
+                    }
+                    else
+                    {
+                        label4bl.Text = "CD";
+                        textBox4BL.Text = "";
+                    }
+
+                    if (nand.bl.CE > 0)
+                    {
+                        label5bl.Text = nand.bl._5BL_magic;
+                        textBox5BL.Text = nand.bl.CE.ToString();
+                    }
+                    else
+                    {
+                        label5bl.Text = "CE";
+                        textBox5BL.Text = "";
+                    }
+
                     if (nand.bl.CF_0 > 0) textBox6BL_p0.Text = nand.bl.CF_0.ToString();
                     else textBox6BL_p0.Text = "";
                     if (nand.bl.CF_1 > 0) textBox6BL_p1.Text = nand.bl.CF_1.ToString();
@@ -97,24 +152,7 @@ namespace JRunner.Panels
                     textBoxpd_0.Text = nand.uf.pd_0;
                     textBoxpd_1.Text = nand.uf.pd_1;
 
-                    if (nand.bl.CB_B != 0)
-                    {
-                        textBox2BLb.Text = nand.bl.CB_B.ToString();
-                        if (textBox2BLb.Text == "15432") textBoxCbType.Text = "RGH3";
-                        else textBoxCbType.Text = "Split";
-                        textBox2BLb.Enabled = true;
-                        label2blb.Visible = true;
-                        label2bla.Visible = true;
-                        label2bl.Visible = false;
-                    }
-                    else
-                    {
-                        textBox2BLb.Enabled = false;
-                        textBoxCbType.Text = "Single";
-                        label2blb.Visible = false;
-                        label2bla.Visible = false;
-                        label2bl.Visible = true;
-                    }
+
 
                     if (textBox2BLb.Text == "15432") // It's not currently possible to properly parse the triple CB setup in RGH3
                     {
@@ -247,7 +285,6 @@ namespace JRunner.Panels
         {
             lblfcrt.Visible = false;
             lblhashed.Visible = false;
-            label2bl.Visible = false;
         }
 
         private void NandInfo_DragDrop(object sender, DragEventArgs e)

--- a/J-Runner/Panels/NandInfo.cs
+++ b/J-Runner/Panels/NandInfo.cs
@@ -153,7 +153,6 @@ namespace JRunner.Panels
                     textBoxpd_1.Text = nand.uf.pd_1;
 
 
-
                     if (textBox2BLb.Text == "15432") // It's not currently possible to properly parse the triple CB setup in RGH3
                     {
                         textBoxldv_cb.Text = textBoxpd_cb.Text = "";

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -1334,6 +1334,10 @@ namespace JRunner.Panels
 
             string ini = (variables.launchpath + @"\" + variables.dashversion + @"\_" + variables.ttyp + ".ini");
 
+            // xeBuild does not officially support creating images for 64mb xenon, zephyr, or falcon
+            // in retail/glitch/glitch2/devGL modes. HOWEVER, it does support devkit images, so if the
+            // selected hack type is DevGL, we can create and patch a devkit image with pre and post
+            // xeBuild patching steps
             if( (variables.ctype.ID == 7 || variables.ctype.ID == 13 || variables.ctype.ID == 14) &&
                  variables.ttyp != variables.hacktypes.devgl )
             {

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -1334,7 +1334,8 @@ namespace JRunner.Panels
 
             string ini = (variables.launchpath + @"\" + variables.dashversion + @"\_" + variables.ttyp + ".ini");
 
-            if (variables.ctype.ID == 7 || variables.ctype.ID == 13 || variables.ctype.ID == 14)
+            if( (variables.ctype.ID == 7 || variables.ctype.ID == 13 || variables.ctype.ID == 14) &&
+                 variables.ttyp != variables.hacktypes.devgl )
             {
                 if (MessageBox.Show("XeBuild does not support building 64MB images for Xenon, Zephyr, or Falcon\n\nContinuing will cause a 16MB image to be built\n\nDo you want to continue?", "Steep Hill Ahead", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
                 {


### PR DESCRIPTION
For DevGL image types, XeBuild supports 16mb SB consoles, 256/512mb BB consoles, and 4GB emmc consoles. However, it does NOT support 64mb small block consoles for DevGL, so those that want to build a 64mb xenon/zephyr/falcon machine with XDKbuild or RGLoader are out of luck.

However- it DOES support 64mb small block consoles for the Devkit image type. In addition, xeBuild will automatically re-sign a patched SD for the devkit image type. We can take advantage of this functionality, plus some image patching, to effectively produce a 64mb DevGL image with XDKbuild, RGLoader, or any other sort of image. For a seamless experience as if xeBuild supported this natively, there's a pre-build and a post-build patching step:

Pre-build patching consists of generating a pre-patched SD to be fed to XeBuild, and modifying the ini file with the new crc. This pre-patching step uses a standard xeBuild patch file as input.

XeBuild is then run in devkit mode to generate an image with our patched SD.

Post-build patching consists of the following steps:

1. Load and parse a xeBuild format patch file, and extract the kernel/hv portion from the file
2. Construct a fake fuse set from the CPU key entered in the main window
3. Patch these in to NAND at 0xE0000, just like DevGL (SD + kernel patches expect this location)
5. Set the XeLL startup reason bytes at the beginning of NAND such that starting the console with eject will boot XeLL
   - Note: Different SD patches are still required to boot XeLL since it lives at 0xF4000 in a devkit image, rather than 0xF0000
6. Zero-pair the SB
7. Fix the patch slot addresses for the SD patching engine 

To that effect, this PR makes the following changes:

- Adds a "devkit not devgl" mode that runs xeBuild in devkit mode when the devgl option is selected (use the F10 key to toggle)
- Move some BL crc calculation code to xeBuild.cs
- Add a "patch bootloader" function that takes a xeBuild patch section as input and patches the BL in the same way as xeBuild
- Adds functions to xeBuild.cs to parse a patch file and return the 2BL, 4BL, and Kernel/HV patch sections individually
- Adds functions to xeBuild.cs to automatically create a devkit image when DevGL + a 64mb console is selected
- Adds a new post-build step to perform a devkit to devgl conversion, and some cleanup for post-build steps
- Prevent the 64mb error message from showing when a 64mb console + DevGL is selected
- Implements the above patching as both a post build step, and as a manual option under the advanced toolstrip menu

This PR also has some related features that aren't directly in furtherance of the 64mb DevGL support, but assisted along the way:
- Add support for the NAND info panel to properly show the bootloader names (pulled from the magic bytes in the BLs)
- Add support for properly decrypting Devkit bootloader stages and saving them when ExtractFiles is enabled
- A few enhancements to the CPU key dialog (verify button, 32 char limit on the text box)



The good thing about this patch set is that existing DevGL patches will boot to the dashboard fine- however, XeLL will not work since xeBuild starts the filesystem later than on a DevGL image (0xF4000 vs 0xF000). SD patches will need to be updated.

For XDKbuild, i've attached the required _devkit.ini and patches_devjasper.bin for both XeLL and the dashboard to work. 

Refer to https://github.com/Pheeeeenom/J-Runner-with-Extras/pull/11 for the correct INI files

Patches are based on my [XDKBuild-With-Extras](https://github.com/mitchellwaite/XDKBuild-With-Extras) repository, and this patch set is effectively the same as the 16mb patch set, but without HDD redirection and an extra instruction to set the XeLL offset correctly 