### PR TITLE
Additional fixes for 64mb DevGL support

### DIFF
--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -467,6 +467,23 @@ namespace JRunner.Classes
             return true;
         }
 
+        public static void devgl64PostBuildActions(string iniFilePath)
+        {
+            // Delete all the patches we created in the pre-build step
+            string khv_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "vfuses_khv.bin");
+            string xell_reason_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "xell_reason.bin");
+            string patch64_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_64.bin");
+            string patch70_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_70.bin");
+
+            if(File.Exists(khv_path)) File.Delete(khv_path);
+            if(File.Exists(xell_reason_path)) File.Delete(xell_reason_path);
+            if(File.Exists(patch64_path)) File.Delete(patch64_path);
+            if(File.Exists(patch70_path)) File.Delete(patch70_path);
+
+            // When building a 64mb DevGL NAND, we need to manually zero-pair the SB as the last step
+            Nand.Nand.zeroPairDevkitSb(Path.Combine(variables.xefolder, variables.updflash), true);
+        }
+
         public void loadvariables(string cpukey, variables.hacktypes ttype, string dash, consoles ctype, List<string> patches, Nand.PrivateN nand, bool altoptions, bool DLpatches, bool includeLaunch, bool audclamp, bool rjtag, bool cleansmc, bool cr4, bool smcp, bool rgh3, bool bigffs, bool zfuse, bool xdkbuild, bool xlusb, bool xlhdd, bool xlboth, bool usbdsec, bool coronakeyfix, bool fullDataClean)
         {
             this._cpukey = cpukey;
@@ -1108,7 +1125,7 @@ namespace JRunner.Classes
                 }
                 else
                 {
-                    arguments = "-t " + _ttype;
+                    arguments = "-t " + variables.hacktypes.devgl;
                 }
             }
             else
@@ -1271,8 +1288,7 @@ namespace JRunner.Classes
                         // Delete the backup, since we were successful in building the NAND image
                         if(File.Exists(iniFileBackupPath)) File.Delete(iniFileBackupPath);
 
-                        // This is a 64mb DevGL image so we've got to manually zeropair the SB
-                        Nand.Nand.zeroPairDevkitSb(Path.Combine(variables.xefolder, variables.updflash), true);
+                        devgl64PostBuildActions(iniFilePath);
                     }
 
                 }

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -1096,6 +1096,9 @@ namespace JRunner.Classes
                         // restore the ini contents from the backup and then bail
                         File.WriteAllLines(iniFilePath, iniFileContentsBackup);
 
+                        // Delete the secondary backup file
+                        if (File.Exists(iniFileBackupPath)) File.Delete(iniFileBackupPath);
+
                         variables.xefinished = true;
                         MainForm.mainForm.xPanel.xeExitActual(false);
                         return;

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -1020,6 +1020,7 @@ namespace JRunner.Classes
             string patchFileBaseName = "";
             string patchFilePath = "";
             string iniFilePath = "";
+            string iniFileBackupPath = "";
             string[] iniFileContentsBackup = { };
 
             // Type overrides, check doSomeChecks() if changing
@@ -1078,6 +1079,8 @@ namespace JRunner.Classes
 
                     // We also need to make sure the ini file exists, because we'll need to pre-patch the SD
                     iniFilePath = variables.rootfolder + @"\xeBuild\" + _dash + "\\_devkit.ini";
+                    iniFileBackupPath = iniFilePath + ".bak";
+
                     if (!File.Exists(iniFilePath))
                     {
                         Console.WriteLine("Could not create 64mb DevGL image, _devgl.ini for dashboard " + _dash + " missing.");
@@ -1086,6 +1089,7 @@ namespace JRunner.Classes
 
                     // Make a backup of the ini file contents before we patch the ini and run XeBuild
                     iniFileContentsBackup = File.ReadAllLines(iniFilePath);
+                    File.WriteAllLines(iniFileBackupPath, iniFileContentsBackup);
 
                     if (!devgl64PreBuildActions(boardtype,iniFilePath,patchFilePath, _cpukey))
                     {
@@ -1262,11 +1266,11 @@ namespace JRunner.Classes
                         // Now that XeBuild is done, we can restore the contents of the ini file
                         File.WriteAllLines(iniFilePath, iniFileContentsBackup);
 
-                        // This is a 64mb DevGL image that we've got to patch... annoying af but that's xeBuild for us
-                        Nand.Nand.convertDevkitToDevGL(Path.Combine(variables.xefolder, variables.updflash),
-                                                       _cpukey,
-                                                       patchFilePath,
-                                                       true);
+                        // Delete the backup, since we were successful in building the NAND image
+                        if(File.Exists(iniFileBackupPath)) File.Delete(iniFileBackupPath);
+
+                        // This is a 64mb DevGL image so we've got to manually zeropair the SB
+                        Nand.Nand.zeroPairDevkitSb(Path.Combine(variables.xefolder, variables.updflash), true);
                     }
 
                 }

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -1112,8 +1112,6 @@ namespace JRunner.Classes
                         // If we failed to patch the SD and/or update the ini,
                         // restore the ini contents from the backup and then bail
                         File.WriteAllLines(iniFilePath, iniFileContentsBackup);
-
-                        // Delete the secondary backup file
                         if (File.Exists(iniFileBackupPath)) File.Delete(iniFileBackupPath);
 
                         variables.xefinished = true;
@@ -1262,6 +1260,17 @@ namespace JRunner.Classes
                     pProcess.CancelOutputRead();
                 }
 
+                // Do any mandatory post build actions here
+                if (_ttype == variables.hacktypes.devgl && (_ctype.ID == 7 || _ctype.ID == 13 || _ctype.ID == 14))
+                {
+                    // Now that XeBuild is done, we can restore the contents of the
+                    // ini file and delete the backup. We have to do this regardless
+                    // of whether the build succeeded or failed
+                    File.WriteAllLines(iniFilePath, iniFileContentsBackup);
+                    if (File.Exists(iniFileBackupPath)) File.Delete(iniFileBackupPath);
+                }
+
+                // Any post-build actions on success here
                 if (success)
                 {
                     // Any post-xeBuild actions are done here. Ensure the postBuildActionsAreRequired
@@ -1282,15 +1291,8 @@ namespace JRunner.Classes
                     }
                     else if (_ttype == variables.hacktypes.devgl && (_ctype.ID == 7 || _ctype.ID == 13 || _ctype.ID == 14))
                     {
-                        // Now that XeBuild is done, we can restore the contents of the ini file
-                        File.WriteAllLines(iniFilePath, iniFileContentsBackup);
-
-                        // Delete the backup, since we were successful in building the NAND image
-                        if(File.Exists(iniFileBackupPath)) File.Delete(iniFileBackupPath);
-
                         devgl64PostBuildActions(iniFilePath);
                     }
-
                 }
             }
             catch (Exception objException)

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -455,15 +455,6 @@ namespace JRunner.Classes
             byte[] xellStartupReason = { 0x00, 0x12 };
             File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), "xell_reason.bin"), xellStartupReason);
 
-            // XeBuild doesn't set the offsets at 0x64 and 0x70 correctly, so
-            // we need to manually patch those for the SD patches to properly
-            // find the vfuses and kernel + hypervisor patches
-            byte[] patchAddress64 = { 0x00, 0x0D, 0x00, 0x00 };
-            byte[] patchAddress70 = { 0x00, 0x01, 0x00, 0x00 };
-
-            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_64.bin"), patchAddress64);
-            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_70.bin"), patchAddress70);
-
             return true;
         }
 
@@ -472,13 +463,9 @@ namespace JRunner.Classes
             // Delete all the patches we created in the pre-build step
             string khv_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "vfuses_khv.bin");
             string xell_reason_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "xell_reason.bin");
-            string patch64_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_64.bin");
-            string patch70_path = Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_70.bin");
 
             if(File.Exists(khv_path)) File.Delete(khv_path);
             if(File.Exists(xell_reason_path)) File.Delete(xell_reason_path);
-            if(File.Exists(patch64_path)) File.Delete(patch64_path);
-            if(File.Exists(patch70_path)) File.Delete(patch70_path);
 
             // When building a 64mb DevGL NAND, we need to manually zero-pair the SB as the last step
             Nand.Nand.zeroPairDevkitSb(Path.Combine(variables.xefolder, variables.updflash), true);

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using System.Threading;
 

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using System.Threading;
 
@@ -276,10 +277,11 @@ namespace JRunner.Classes
             return blData;
         }
 
-        public static bool patchSdAndUpdateIniFile(string boardtype, string iniFilePath, string xeBuildPatchFilePath)
+        public static bool devgl64PreBuildActions(string boardtype, string iniFilePath, string xeBuildPatchFilePath, string cpukey)
         {
             byte[] xeBuildPatchFileBytes = { };
             byte[] xeBuildSdPatchSectionBytes = { };
+            byte[] xeBuildKernelHvPatchSectionBytes = { };
 
             try
             {
@@ -293,6 +295,7 @@ namespace JRunner.Classes
             }
 
             xeBuildSdPatchSectionBytes = return4blPatchSet(xeBuildPatchFileBytes);
+            xeBuildKernelHvPatchSectionBytes = returnKernelHvPatchSet(xeBuildPatchFileBytes);
 
             // Grab the board type from the ini file
             string[] iniLines = File.ReadAllLines(iniFilePath);
@@ -325,7 +328,7 @@ namespace JRunner.Classes
             // Split it by the comma so we get the filename and CRC
             string[] sdLine = iniLines[iniSdEntryLine].Split(',');
 
-            if (variables.debugMode) Console.WriteLine("SD expected pre-patching: " + sdLine);
+            if (variables.debugMode) Console.WriteLine("SD expected pre-patching: " + iniLines[iniSdEntryLine]);
 
             string sdFileName = sdLine[0];
             long sdIniCrc = Convert.ToInt64(sdLine[1], 16);
@@ -398,6 +401,69 @@ namespace JRunner.Classes
 
             // Write the new ini file
             File.WriteAllLines(iniFilePath, iniLines);
+
+            // We've patched the bootloader, now generate fuses+kernel patch binary file
+            byte[] vfuseAndKernelPatchData = new byte[0x60 + xeBuildKernelHvPatchSectionBytes.Length];
+
+            // bytes we use for making up the vfuses
+            // Fuseline 0 and 1 are always the same for a devkit
+            // 3/4 and 5/6 make up the CPU key
+            // CB LDV and CF/CG LDV can be left blank
+            byte[] fuseline0 = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+            byte[] fuseline1_dev = { 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F };
+            byte[] fuseline3_4 = Oper.StringToByteArray(cpukey.Substring(0, 16));
+            byte[] fuseline5_6 = Oper.StringToByteArray(cpukey.Substring(16, 16));
+
+            // Build the fake fuseset
+            Buffer.BlockCopy(fuseline0, 0, vfuseAndKernelPatchData, 0, 0x8);
+            Buffer.BlockCopy(fuseline1_dev, 0, vfuseAndKernelPatchData, 0x8, 0x8);
+            Buffer.BlockCopy(fuseline3_4, 0, vfuseAndKernelPatchData, 0x18, 0x8);
+            Buffer.BlockCopy(fuseline3_4, 0, vfuseAndKernelPatchData, 0x20, 0x8);
+            Buffer.BlockCopy(fuseline5_6, 0, vfuseAndKernelPatchData, 0x28, 0x8);
+            Buffer.BlockCopy(fuseline5_6, 0, vfuseAndKernelPatchData, 0x30, 0x8);
+
+            // Build the vfuse/kernel patch section
+            Buffer.BlockCopy(xeBuildKernelHvPatchSectionBytes, 0, vfuseAndKernelPatchData, 0x60, xeBuildKernelHvPatchSectionBytes.Length);
+
+            // Write the file to disk so xeBuild can pick it up
+            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), "vfuses_khv.bin"), vfuseAndKernelPatchData);
+
+            // XeBuild does not set the XeLL startup reason for a devkit image.
+            // For the SD patches to know when to jump to XeLL, it must be set
+            // manually and can be patched in to the NAND image. Here, the XeLL
+            // startup reason is being set to 0x00 (ignore) and 0x12 (eject)
+            #region valid xell startup reasons
+            // IGNORE          = 0x00
+            // POWER           = 0x11
+            // EJECT           = 0x12
+            // UNDOCUMENTED_15 = 0x15
+            // UNDOCUMENTED_16 = 0x16
+            // REMOPOWER       = 0x20
+            // UNDOCUMENTED_21 = 0x21
+            // REMOX           = 0x22
+            // WINBUTTON       = 0x24
+            // UNDOCUMENTED_30 = 0x30
+            // UNDOCUMENTED_31 = 0x31
+            // KIOSK           = 0x41
+            // WIRELESSX       = 0x55
+            // WIREDXF1        = 0x56
+            // WIREDXF2        = 0x57
+            // WIREDXB2        = 0x58
+            // WIREDXB1        = 0x59
+            // WIREDXB3        = 0x5A
+            #endregion
+
+            byte[] xellStartupReason = { 0x00, 0x12 };
+            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), "xell_reason.bin"), xellStartupReason);
+
+            // XeBuild doesn't set the offsets at 0x64 and 0x70 correctly, so
+            // we need to manually patch those for the SD patches to properly
+            // find the vfuses and kernel + hypervisor patches
+            byte[] patchAddress64 = { 0x00, 0x0D, 0x00, 0x00 };
+            byte[] patchAddress70 = { 0x00, 0x01, 0x00, 0x00 };
+
+            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_64.bin"), patchAddress64);
+            File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(iniFilePath), "patch_70.bin"), patchAddress70);
 
             return true;
         }
@@ -994,6 +1060,7 @@ namespace JRunner.Classes
                 if (variables.devkitnotdevgl)
                 {
                     Console.WriteLine("Using devkit image type instead of DevGL");
+                    arguments = "-t " + variables.hacktypes.devkit;
                 }
                 else if (_ctype.ID == 7 || _ctype.ID == 13 || _ctype.ID == 14)
                 {
@@ -1017,10 +1084,10 @@ namespace JRunner.Classes
                         return;
                     }
 
-                    // Take a backup of the ini file contents before we patch the ini and run XeBuild
+                    // Make a backup of the ini file contents before we patch the ini and run XeBuild
                     iniFileContentsBackup = File.ReadAllLines(iniFilePath);
 
-                    if(!patchSdAndUpdateIniFile(boardtype,iniFilePath,patchFilePath))
+                    if (!devgl64PreBuildActions(boardtype,iniFilePath,patchFilePath, _cpukey))
                     {
                         // If we failed to patch the SD and/or update the ini,
                         // restore the ini contents from the backup and then bail
@@ -1030,9 +1097,13 @@ namespace JRunner.Classes
                         MainForm.mainForm.xPanel.xeExitActual(false);
                         return;
                     }
-                }
 
-                arguments = "-t " + variables.hacktypes.devkit;
+                    arguments = "-t " + variables.hacktypes.devkit;
+                }
+                else
+                {
+                    arguments = "-t " + _ttype;
+                }
             }
             else
             {
@@ -1193,9 +1264,9 @@ namespace JRunner.Classes
 
                         // This is a 64mb DevGL image that we've got to patch... annoying af but that's xeBuild for us
                         Nand.Nand.convertDevkitToDevGL(Path.Combine(variables.xefolder, variables.updflash),
-                                                        variables.cpukey,
-                                                        patchFilePath,
-                                                        true);
+                                                       _cpukey,
+                                                       patchFilePath,
+                                                       true);
                     }
 
                 }

--- a/J-Runner/Forms/About.Designer.cs
+++ b/J-Runner/Forms/About.Designer.cs
@@ -47,10 +47,9 @@ namespace JRunner.Forms
             // 
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.White;
-            this.label1.Location = new System.Drawing.Point(36, 188);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Location = new System.Drawing.Point(27, 153);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(329, 30);
+            this.label1.Size = new System.Drawing.Size(247, 24);
             this.label1.TabIndex = 1;
             this.label1.Text = "J-Runner with Extras";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -59,11 +58,10 @@ namespace JRunner.Forms
             // 
             this.lblCredits.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblCredits.ForeColor = System.Drawing.Color.White;
-            this.lblCredits.Location = new System.Drawing.Point(36, 247);
-            this.lblCredits.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblCredits.Location = new System.Drawing.Point(27, 201);
             this.lblCredits.Name = "lblCredits";
             this.lblCredits.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.lblCredits.Size = new System.Drawing.Size(329, 62);
+            this.lblCredits.Size = new System.Drawing.Size(247, 50);
             this.lblCredits.TabIndex = 2;
             this.lblCredits.Text = "T\r\nT\r\nT";
             this.lblCredits.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -72,10 +70,9 @@ namespace JRunner.Forms
             // 
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label2.ForeColor = System.Drawing.Color.White;
-            this.label2.Location = new System.Drawing.Point(36, 220);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Location = new System.Drawing.Point(27, 179);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(329, 22);
+            this.label2.Size = new System.Drawing.Size(247, 18);
             this.label2.TabIndex = 4;
             this.label2.Text = "The Ultimate RGH/JTAG App\r\n";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -91,11 +88,10 @@ namespace JRunner.Forms
             // logo
             // 
             this.logo.Image = global::JRunner.Properties.Resources.JR;
-            this.logo.Location = new System.Drawing.Point(41, 18);
-            this.logo.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.logo.Location = new System.Drawing.Point(31, 15);
             this.logo.Name = "logo";
-            this.logo.Size = new System.Drawing.Size(298, 163);
-            this.logo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
+            this.logo.Size = new System.Drawing.Size(224, 132);
+            this.logo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.logo.TabIndex = 0;
             this.logo.TabStop = false;
             // 
@@ -103,10 +99,9 @@ namespace JRunner.Forms
             // 
             this.ver.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.ver.ForeColor = System.Drawing.Color.White;
-            this.ver.Location = new System.Drawing.Point(133, 310);
-            this.ver.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.ver.Location = new System.Drawing.Point(100, 252);
             this.ver.Name = "ver";
-            this.ver.Size = new System.Drawing.Size(135, 22);
+            this.ver.Size = new System.Drawing.Size(101, 18);
             this.ver.TabIndex = 5;
             this.ver.Text = "version";
             this.ver.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -115,10 +110,9 @@ namespace JRunner.Forms
             // 
             this.build.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F);
             this.build.ForeColor = System.Drawing.Color.White;
-            this.build.Location = new System.Drawing.Point(132, 332);
-            this.build.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.build.Location = new System.Drawing.Point(99, 270);
             this.build.Name = "build";
-            this.build.Size = new System.Drawing.Size(137, 22);
+            this.build.Size = new System.Drawing.Size(103, 18);
             this.build.TabIndex = 6;
             this.build.Text = "build";
             this.build.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
@@ -129,20 +123,19 @@ namespace JRunner.Forms
             this.close.AutoSize = true;
             this.close.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.close.ForeColor = System.Drawing.Color.White;
-            this.close.Location = new System.Drawing.Point(368, 10);
-            this.close.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.close.Location = new System.Drawing.Point(276, 8);
             this.close.Name = "close";
-            this.close.Size = new System.Drawing.Size(17, 18);
+            this.close.Size = new System.Drawing.Size(16, 15);
             this.close.TabIndex = 7;
             this.close.Text = "X";
             this.close.Click += new System.EventHandler(this.close_Click);
             // 
             // About
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.Color.Black;
-            this.ClientSize = new System.Drawing.Size(400, 369);
+            this.ClientSize = new System.Drawing.Size(300, 300);
             this.Controls.Add(this.close);
             this.Controls.Add(this.build);
             this.Controls.Add(this.ver);
@@ -152,7 +145,6 @@ namespace JRunner.Forms
             this.Controls.Add(this.logo);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "About";

--- a/J-Runner/Forms/About.cs
+++ b/J-Runner/Forms/About.cs
@@ -20,6 +20,7 @@ namespace JRunner.Forms
                                     "SGCSam: 6717/9199 XeBuild Patches",
                                     "wurthless-elektroniks: Hacked 7378 CB_B for Elpis+Samsung",
                                     "Xvistaman2005: XDKbuild",
+                                    "Harley David-San:\n64mb DevGL support, bugfixes,\nQoL improvements"
         };
         static int contribloc = 0;
         [DllImport("Gdi32.dll", EntryPoint = "CreateRoundRectRgn")]

--- a/J-Runner/MainForm.Designer.cs
+++ b/J-Runner/MainForm.Designer.cs
@@ -896,7 +896,7 @@ namespace JRunner
             // 
             this.zeroPairSbToolStripMenuItem.Name = "zeroPairSbToolStripMenuItem";
             this.zeroPairSbToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
-            this.zeroPairSbToolStripMenuItem.Text = "Zero-pair SB";
+            this.zeroPairSbToolStripMenuItem.Text = "Zero pair SB";
             this.zeroPairSbToolStripMenuItem.Click += new System.EventHandler(this.zeroPairSbToolStripMenuItem_Click);
             // 
             // checkSecdataToolStripMenuItem

--- a/J-Runner/MainForm.Designer.cs
+++ b/J-Runner/MainForm.Designer.cs
@@ -110,7 +110,7 @@ namespace JRunner
             this.writeFusionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.convertToRGH3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.convert64mbDevkitToDevGLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.zeroPairSbToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.checkSecdataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.CustomXeBuildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripSeparator();
@@ -845,7 +845,7 @@ namespace JRunner
             this.writeFusionToolStripMenuItem,
             this.toolStripMenuItem1,
             this.convertToRGH3ToolStripMenuItem,
-            this.convert64mbDevkitToDevGLToolStripMenuItem,
+            this.zeroPairSbToolStripMenuItem,
             this.checkSecdataToolStripMenuItem,
             this.CustomXeBuildMenuItem,
             this.toolStripMenuItem5,
@@ -892,12 +892,12 @@ namespace JRunner
             this.convertToRGH3ToolStripMenuItem.Text = "Convert to RGH3";
             this.convertToRGH3ToolStripMenuItem.Click += new System.EventHandler(this.convertToRGH3ToolStripMenuItem_Click);
             // 
-            // convert64mbDevkitToDevGLToolStripMenuItem
+            // zeroPairSbToolStripMenuItem
             // 
-            this.convert64mbDevkitToDevGLToolStripMenuItem.Name = "convert64mbDevkitToDevGLToolStripMenuItem";
-            this.convert64mbDevkitToDevGLToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
-            this.convert64mbDevkitToDevGLToolStripMenuItem.Text = "Convert 64mb Devkit to DevGL";
-            this.convert64mbDevkitToDevGLToolStripMenuItem.Click += new System.EventHandler(this.convert64mbDevkitToDevGLToolStripMenuItem_Click);
+            this.zeroPairSbToolStripMenuItem.Name = "zeroPairSbToolStripMenuItem";
+            this.zeroPairSbToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
+            this.zeroPairSbToolStripMenuItem.Text = "Zero-pair SB";
+            this.zeroPairSbToolStripMenuItem.Click += new System.EventHandler(this.zeroPairSbToolStripMenuItem_Click);
             // 
             // checkSecdataToolStripMenuItem
             // 
@@ -1571,6 +1571,6 @@ namespace JRunner
         private ToolStripMenuItem nANDAlignmentToolStripMenuItem;
         private ToolStripMenuItem gB16MBToolStripMenuItem;
         private ToolStripMenuItem injectXeLLToolStripMenuItem;
-        private ToolStripMenuItem convert64mbDevkitToDevGLToolStripMenuItem;
+        private ToolStripMenuItem zeroPairSbToolStripMenuItem;
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3183,36 +3183,15 @@ namespace JRunner
             }
         }
 
-        private void convert64mbDevkitToDevGLToolStripMenuItem_Click(object sender, EventArgs e)
+        private void zeroPairSbToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (String.IsNullOrWhiteSpace(variables.filename1))
             {
-                Console.WriteLine("Devkit image conversion error: Please select a valid NAND image!");
+                Console.WriteLine("Zeropair SB error: Please select a valid NAND image!");
                 return;
             }
 
-            if (!Nand.Nand.VerifyKey(Oper.StringToByteArray(variables.cpukey)) ||
-                !nand.cpukeyverification(variables.cpukey))
-            {
-                Console.WriteLine("Devkit image conversion error: Bad CPU Key!");
-                return;
-            }
-
-            OpenFileDialog ofd = new OpenFileDialog();
-
-            ofd.FileName = "";
-            ofd.Filter = "xeBuild devkit patch set (patches_dev*.bin)|patches_dev*.bin|All files (*.*)|*.*";
-            ofd.Title = "Select KHV patch";
-            ofd.InitialDirectory = Path.Combine(variables.rootfolder, @"xeBuild\17489\bin");
-            ofd.RestoreDirectory = false;
-
-            if (ofd.ShowDialog() != DialogResult.OK)
-            {
-                Console.WriteLine("Cancelled Devkit image conversion");
-                return;
-            }
-
-            Nand.Nand.convertDevkitToDevGL(variables.filename1, variables.cpukey, ofd.FileName, false);
+            Nand.Nand.zeroPairDevkitSb(variables.filename1, false);
         }
 
         private void sMCConfigViewerToolStripMenuItem1_Click(object sender, EventArgs e)

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2825,23 +2825,13 @@ namespace JRunner.Nand
         }
 
         /// <summary>
-        /// Converts an input devkit image to a DevGL image by doing the following:
-        /// 1 - Patch in virtual fuses and the kernel/hypervisor patch set
-        /// 2 - Set the XeLL startup reason bytes
-        /// 3 - Zero-pair the SB
-        /// 4 - Fix the patch slot addresses for the SD patching engine
+        /// Zero-pairs the SB of a devkit image, the final step in generating a 64mb DevGL image
         /// </summary>
         /// <param name="flashFilePath">Flash image to be patched, result will be written back to the same file</param>
-        /// <param name="cpukey">CPU key for the image, needed to decrypt the KV</param>
-        /// <param name="patchFilePath">Path to the xeBuild patch file to use to patch the devkit image</param>
         /// <param name="sequenced">True if this is part of a xeBuild operation, false otherwise</param>
-        public static void convertDevkitToDevGL(string flashFilePath, string cpukey, string patchFilePath, bool sequenced)
+        public static void zeroPairDevkitSb(string flashFilePath, bool sequenced)
         {
-            // This is where the XDKbuild patches expect the virtual fuses and kernel patches to be
-            int patchOffset = 0xE0000;
-
             byte[] flashData = { };
-            byte[] patchData = { };
 
             try
             {
@@ -2892,8 +2882,6 @@ namespace JRunner.Nand
                 return;
             }
 
-            byte[] khvPatchData = Classes.xebuild.returnKernelHvPatchSet(patchData);
-
             // We're going to assume the image has ECC because this is only
             // really needed for 64mb consoles (Xenon/Zephyr/Falcon).
             int blockType = 0;
@@ -2921,82 +2909,14 @@ namespace JRunner.Nand
                 blockType = identifylayout(sparedata);
             }
 
-            //
-            // Step 1: Create vfuse patch and add kernel/hv patches
-            //
-            byte[] vfuseAndKernelPatchData = new byte[0x60 + khvPatchData.Length];
-            
-            // bytes we use for making up the vfuses
-            // Fuseline 0 and 1 are always the same for a devkit
-            // 3/4 and 5/6 make up the CPU key
-            // CB LDV and CF/CG LDV can be left blank
-            byte[] fuseline0 = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-            byte[] fuseline1_dev = { 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F, 0x0F };
-            byte[] fuseline3_4 = Oper.StringToByteArray(cpukey.Substring(0, 16));
-            byte[] fuseline5_6 = Oper.StringToByteArray(cpukey.Substring(16, 16));
-
-            // Build the fake fuseset
-            Buffer.BlockCopy(fuseline0,     0, vfuseAndKernelPatchData, 0   , 0x8);
-            Buffer.BlockCopy(fuseline1_dev, 0, vfuseAndKernelPatchData, 0x8 , 0x8);
-            Buffer.BlockCopy(fuseline3_4,   0, vfuseAndKernelPatchData, 0x18, 0x8);
-            Buffer.BlockCopy(fuseline3_4,   0, vfuseAndKernelPatchData, 0x20, 0x8);
-            Buffer.BlockCopy(fuseline5_6,   0, vfuseAndKernelPatchData, 0x28, 0x8);
-            Buffer.BlockCopy(fuseline5_6,   0, vfuseAndKernelPatchData, 0x30, 0x8);
-
-            // Build the vfuse/kernel patch section
-            Buffer.BlockCopy(khvPatchData, 0, vfuseAndKernelPatchData, 0x60, khvPatchData.Length);
-
             // Get the physical pages we need to patch by finding out how many
             // logical pages are needed to store the patch data add 1 in case it's
             // not an even multiple of the page size, doesn't really matter if we
             // populate the buffer with an extra page since it's not at the end of NAND
-            byte[] nandPatchPages = flashData.Take(patchOffsetPhys + (((vfuseAndKernelPatchData.Length / pagesz) + 1) * pagesz_phys)).ToArray();
+            byte[] nandPatchPages = flashData.Take(patchOffsetPhys).ToArray();
 
             // remove the ECC so we can copy our patch data to the logical addresses
             nandPatchPages = unecc(nandPatchPages);
-            
-            //
-            // Step 1: copy over our vfuse/kernel patch data to patchOffset
-            //
-            Buffer.BlockCopy(vfuseAndKernelPatchData, 0, nandPatchPages, patchOffset, vfuseAndKernelPatchData.Length);
-
-            //
-            // Step 2: Patch the XeLL startup reason
-            //
-
-            // SD patches look at bytes 0x4E and 0x4F to determine when
-            // to jump to XeLL rather than booting the kernel. This is
-            // normally patched in by XeBuild but we have to do it manually
-            // for a devkit image. This is always located in the first page,
-            // so we can set it at the same time as zeropairing the SB
-            //
-            // Powerup cause values:
-            //
-            // POWER           = 0x11
-            // EJECT           = 0x12
-            // UNDOCUMENTED_15 = 0x15
-            // UNDOCUMENTED_16 = 0x16
-            // REMOPOWER       = 0x20
-            // UNDOCUMENTED_21 = 0x21
-            // REMOX           = 0x22
-            // WINBUTTON       = 0x24
-            // UNDOCUMENTED_30 = 0x30
-            // UNDOCUMENTED_31 = 0x31
-            // KIOSK           = 0x41
-            // WIRELESSX       = 0x55
-            // WIREDXF1        = 0x56
-            // WIREDXF2        = 0x57
-            // WIREDXB2        = 0x58
-            // WIREDXB1        = 0x59
-            // WIREDXB3        = 0x5A
-
-            // Set the powerup causes to 0x0 (ignore) and 0x12 (eject)
-            nandPatchPages[0x4E] = 0x0;
-            nandPatchPages[0x4F] = 0x12;
-
-            //
-            // Step 3: Zero pair the SB
-            //
 
             // Encryption of the SC and later stages are different compared
             // to retail CB/CD encryption- SC uses a zero key and nonce
@@ -3038,28 +2958,6 @@ namespace JRunner.Nand
             // Re-encrypt the SB and place it back in the patch data
             sb_crypt = encrypt_CB(sb_decrypt, sb_nonce, ref sb_key);
             Buffer.BlockCopy(sb_crypt, 0, nandPatchPages, sbOffset, sbLength);
-
-            //
-            // Step 4: Change the patch slot addresses at the beginning of NAND
-            //
-
-            // The SD patching engine looks at two DWORDs, at 0x64 and 0x70
-            // to determine where to look for patches. To be able to find
-            // patches at 0xE0000, 0x64 and 0x70 need to be:
-            // 0x64 = 0x00 0x0D 0x00 0x00
-            // 0x70 = 0x00 0x01 0x00 0x00
-            //
-            // because 0xD0000 + 0x10000 = 0xE0000
-            //
-            nandPatchPages[0x64] = 0x00;
-            nandPatchPages[0x65] = 0x0D;
-            nandPatchPages[0x66] = 0x00;
-            nandPatchPages[0x67] = 0x00;
-
-            nandPatchPages[0x70] = 0x00;
-            nandPatchPages[0x71] = 0x01;
-            nandPatchPages[0x72] = 0x00;
-            nandPatchPages[0x73] = 0x00;
 
             // Re-add ECC data and copy it over to the flash data buffer
             nandPatchPages = addecc_v2(nandPatchPages,true,0,blockType);

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2833,13 +2833,22 @@ namespace JRunner.Nand
         {
             byte[] flashData = { };
 
+            // Logical page size is always 0x200
+            // and the physical page size (for ECC images) is always 0x210
+            int pagesz = 0x200;
+            int pagesz_phys = 0x210;
+
+            int blockType = 0;
+            bool flashHasEcc = false;
+
+            // Read in the flash image
             try
             {
                 flashData = File.ReadAllBytes(flashFilePath);
             }
             catch(Exception ex)
             {
-                Console.WriteLine("Devkit image conversion error: couldn't read input flash image");
+                Console.WriteLine("Zero pair SB error: couldn't read input flash image");
                 if (variables.debugMode) Console.WriteLine(ex.ToString());
 
                 if (sequenced)
@@ -2850,13 +2859,20 @@ namespace JRunner.Nand
                 return;
             }
 
-            // Ensure we're working with a 64mb image, with ECC
-            // which is 69206016 bytes long. No patching is necessary
-            // for 16mb/BB/non-ECC images
-            if (flashData.Length != 69206016)
+            // Determine whether this image has ECC
+            if (flashData.Length == 17301504 || flashData.Length == 69206016)
             {
-                Console.WriteLine("Devkit image conversion error: Only 64mb images are supported.");
-
+                flashHasEcc = true;
+            }
+            else if (flashData.Length == 50331648)
+            {
+                // Flash data doesn't have ECC, pagesz_phys = pagesz
+                flashHasEcc = false;
+                pagesz_phys = pagesz;
+            }
+            else
+            {
+                Console.WriteLine("Zero pair SB error: Invalid flash image size");
                 if (sequenced)
                 {
                     variables.xefinished = true;
@@ -2864,38 +2880,6 @@ namespace JRunner.Nand
                 }
                 return;
             }
-
-            try
-            {
-                patchData = File.ReadAllBytes(patchFilePath);
-            }
-            catch(Exception ex)
-            {
-                Console.WriteLine("Devkit image conversion error: couldn't read input patch data");
-                if (variables.debugMode) Console.WriteLine(ex.ToString());
-
-                if (sequenced)
-                {
-                    variables.xefinished = true;
-                    MainForm.mainForm.xPanel.xeExitActual(false);
-                }
-                return;
-            }
-
-            // We're going to assume the image has ECC because this is only
-            // really needed for 64mb consoles (Xenon/Zephyr/Falcon).
-            int blockType = 0;
-            bool flashHasEcc = true;
-
-            // Logical page size is always 0x200
-            // and the physical page size (with spare data) is always 0x210
-            int pagesz = 0x200;
-            int pagesz_phys = 0x210;
-
-            // Calculate the physical offset into the NAND image where we
-            // need to write the vfuses and kernel patch data
-            int patchPageNumber = patchOffset / pagesz;
-            int patchOffsetPhys = patchPageNumber * pagesz_phys;
 
             // If the flash has ECC data, determine the block type so ECC data can be recalculated
             if (flashHasEcc)
@@ -2909,15 +2893,6 @@ namespace JRunner.Nand
                 blockType = identifylayout(sparedata);
             }
 
-            // Get the physical pages we need to patch by finding out how many
-            // logical pages are needed to store the patch data add 1 in case it's
-            // not an even multiple of the page size, doesn't really matter if we
-            // populate the buffer with an extra page since it's not at the end of NAND
-            byte[] nandPatchPages = flashData.Take(patchOffsetPhys).ToArray();
-
-            // remove the ECC so we can copy our patch data to the logical addresses
-            nandPatchPages = unecc(nandPatchPages);
-
             // Encryption of the SC and later stages are different compared
             // to retail CB/CD encryption- SC uses a zero key and nonce
             // and the SD depends on the SC key. e.g.
@@ -2927,14 +2902,51 @@ namespace JRunner.Nand
             // sd_key = XeCryptHmacSha(sc_key, sd_nonce)
             // sd_key = XeCryptHmacSha(sd_key, se_nonce)
             // 
-            // So, we can decrypt and zeropair the SB without touching later stages
+            // So, we can decrypt and zeropair the SB without touching
+            // later stages. Isn't that convenient!
 
-            // Determine the offset and length of the SB
-            int sbOffset = BitConverter.ToInt32(nandPatchPages.Skip(0x8).Take(4).Reverse().ToArray(), 0);
-            int sbLength = BitConverter.ToInt32(nandPatchPages.Skip(sbOffset + 12).Take(4).Reverse().ToArray(), 0);
+            // Determine the logical SB offset by looking at 0x8 in NAND
+            // Then calculate the physical offset and offset in page
+            int logicalSbOffset = BitConverter.ToInt32(flashData.Skip(0x8).Take(4).Reverse().ToArray(), 0);
+            int sbOffsetInPage = logicalSbOffset % pagesz;
+
+            // Calculate the offset of the first page containing the SB
+            int physicalSbPageOffset = (logicalSbOffset / pagesz) * pagesz_phys;
+
+            // The size of the SB is stored in its header, which is 0xC in to the SB binary
+            int sbSize = BitConverter.ToInt32(flashData.Skip(physicalSbPageOffset + 0xC).Take(4).Reverse().ToArray(), 0);
+
+            // Get the length of data to read from NAND, which is the (SB size / page size) + 1
+            // in case the SB doesn't start on a page boundary or the size of the SB isn't an 
+            // exact multiple of the page size.
+            int patchDataLength = ((sbSize / pagesz) + 1) * pagesz_phys;
+
+            // Get the pages of the SB that we need to patch
+            byte[] nandPatchPages = flashData.Skip(physicalSbPageOffset).Take(patchDataLength).ToArray();
+
+            if (flashHasEcc)
+            {
+                // remove the ECC so we can copy our patch data to the logical addresses
+                nandPatchPages = unecc(nandPatchPages);
+            }
 
             // Extract the encrypted SB data
-            byte[] sb_crypt = nandPatchPages.Skip(sbOffset).Take(sbLength).ToArray();
+            byte[] sb_crypt = nandPatchPages.Skip(sbOffsetInPage).Take(sbSize).ToArray();
+
+            // Check that we actually read an SB by checking the magic bytes
+            // at 0x0 and 0x1, they should be 0x53 (S) and 0x42 (B).
+            // This function does not support zeropairing CB or CF/CG
+            if(sb_crypt[0] != 0x53 || sb_crypt[1] != 0x42)
+            {
+                Console.WriteLine("Zero pair SB error: BL at offset " + logicalSbOffset.ToString("X") + " is not an SB.");
+
+                if (sequenced)
+                {
+                    variables.xefinished = true;
+                    MainForm.mainForm.xPanel.xeExitActual(false);
+                }
+                return;
+            }
 
             // Decrypt the SB (it's encrypted the same way as a retail single CB or split CB_A)
             byte[] sb_decrypt = Nand.decrypt_CB(sb_crypt);
@@ -2957,11 +2969,11 @@ namespace JRunner.Nand
 
             // Re-encrypt the SB and place it back in the patch data
             sb_crypt = encrypt_CB(sb_decrypt, sb_nonce, ref sb_key);
-            Buffer.BlockCopy(sb_crypt, 0, nandPatchPages, sbOffset, sbLength);
+            Buffer.BlockCopy(sb_crypt, 0, nandPatchPages, sbOffsetInPage, sbSize);
 
             // Re-add ECC data and copy it over to the flash data buffer
-            nandPatchPages = addecc_v2(nandPatchPages,true,0,blockType);
-            Buffer.BlockCopy(nandPatchPages, 0, flashData, 0, nandPatchPages.Length);
+            nandPatchPages = addecc_v2(nandPatchPages, true, physicalSbPageOffset, blockType);
+            Buffer.BlockCopy(nandPatchPages, 0, flashData, physicalSbPageOffset, nandPatchPages.Length);
 
             try
             {
@@ -2970,7 +2982,7 @@ namespace JRunner.Nand
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Devkit image conversion error: couldn't write modified flash image");
+                Console.WriteLine("Zero pair SB error: couldn't write modified flash image");
                 if (variables.debugMode) Console.WriteLine(ex.ToString());
 
                 if (sequenced)
@@ -2981,7 +2993,7 @@ namespace JRunner.Nand
                 return;
             }
 
-            Console.WriteLine("Successfully converted Devkit image to DevGL");
+            Console.WriteLine("Successfully zero paired SB");
             Console.WriteLine("");
 
             if(sequenced)

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -3975,11 +3975,7 @@ namespace JRunner.Nand
                 val >>= 1;
             }
             val = ~val;
-
-            // For some values of val, the below stmt would return less than a 4 byte array
-            // (32-bit number). To ensure 4 bytes is always returned, "X8" replaces "X"
-            // in the ToString method below
-            byte[] temp = Oper.StringToByteArray(((val << 6) & 0xFFFFFFFF).ToString("X8"));
+            byte[] temp = Oper.StringToByteArray(((val << 6) & 0xFFFFFFFF).ToString("X"));
             Array.Reverse(temp);
             for (int j = data.Length - 4; j != data.Length; j++) data[j] = temp[j - data.Length + 4];
             return data;


### PR DESCRIPTION
Reviewing the previous delivery, there are some opportunities for improvement to the previous delivery that simplifies the code in Jrunner itself.

Namely:

- Let xeBuild patch the fuses, kernel patches and xell startup reason in to the raw image for us, using the `[rawpatch]` functionality of the ini. That way, the only post-build step is zeropairing the SB. This simplifies the code a bunch.
   - As part of a pre-build step, J-Runner will generate a `vfuses_khv.bin`, `xell_reason.bin`. For existing SD and SE patches, 0x64 and 0x70 can be patched (the system update slots) so that existing SD and SE patches can find the kernel+vfuses. Updated SD and SE patches are the best course of action though, as xeBuild will freak when a NAND with this patch is used as input. The attached XDKbuild patch set includes changes to look at 0xE4000 to prevent xeBuild from having a fit
   
```
;On a Devkit NAND, xeBuld expects the patch slot to be at
;0xE4000. However, regular devGL patches expect it to be
;at 0xE0000. To be able to use standard DevGL patches on
;a 64mb devGL image (XeLL will not work due to the flashfs
;offset difference), the following lines can be added to
;the rawpatch section below and vfuses_khv.bin can be
;changed to 0xE0000.
; 
;devgl64_patch_0x64.bin,0x64
;devgl64_patch_0x70.bin,0x70
;
;On a standard devkit NAND, 0x64 is set to 0x000D4000, while
;0x70 is set to 0x00010000, which means that the system update
;slot is 0x4000 later in NAND compared to a standard DevGL image
;and both the SD and SE patches need to be updated to be able
;to handle images without the patchslot address change
;
[rawpatch]
vfuses_khv.bin,0xE4000
xell_reason.bin,0x4E
```

- Update the SB zeropairing code to be able to work on any image type
- Fix DevGL image creation (setting `arguments = "-t " + variables.hacktypes.devkit;` was accidentally after the closing brace, not before)
- Revert a change I made to calcecc() made in the last delivery. It was required to fix the previous NAND patching code, but is not needed with the new change and is being reverted in case there are unintended side effects.
 - Shameless self plug in the credits section :)

I've attached an updated ini + patch set zip file and will delete the one from the previous PR
[17489_devgl_64mb.zip](https://github.com/user-attachments/files/23226984/17489_devgl_64mb.zip)
