### PR TITLE
Don't use falcon board type for everything!

### DIFF
--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -1250,7 +1250,7 @@ namespace JRunner.Classes
                     // otherwise the CB/CD/CE patches won't be able to find the vfuses
                     if(isAffectedByXeBuildImageBug())
                     {
-                        Nand.Nand.fixPatchSlotSizeForBuggyImage(Path.Combine(variables.xefolder, variables.updflash));
+                        Nand.Nand.fixBuggyXeBuildImage(Path.Combine(variables.xefolder, variables.updflash));
                     }
 
                     if (_xdkbuild && _rgh3)

--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -900,18 +900,6 @@ namespace JRunner.Classes
 
             // Type overrides, check doSomeChecks() if changing
             string boardtype = _ctype.Ini;
-            if (_ttype == variables.hacktypes.glitch2 || _ttype == variables.hacktypes.glitch2m || _ttype == variables.hacktypes.devgl)
-            {
-                if (boardtype == "xenon")
-                {
-                    boardtype = "falcon";
-                }
-                else if (boardtype == "zephyr")
-                {
-                    boardtype = "falcon";
-                }
-            }
-
             string ctypebtldr = boardtype + "bl";
             if (!File.Exists(ini)) return XebuildError.noinis;
             if (!parse_ini.getlabels(ini).Contains(ctypebtldr)) return XebuildError.nobootloaders;
@@ -989,7 +977,7 @@ namespace JRunner.Classes
             if( (_xdkbuild && _ttype != variables.hacktypes.devgl) ||
                 _rgh3 ||
                 isDevglFor64MbConsoles() ||
-                isAffectedByXeBuildFalconImageBug() )
+                isAffectedByXeBuildImageBug() )
             {
                 return true;
             }
@@ -1020,9 +1008,9 @@ namespace JRunner.Classes
             }
         }
 
-        private bool isAffectedByXeBuildFalconImageBug()
+        private bool isAffectedByXeBuildImageBug()
         {
-            // If we've selected the following options, we're building a falcon image
+            // If we've selected the following options, we're building an image
             // that is affected by a bug in XeBuild that doesn't set the patch slot
             // size correctly and need to patch the resulting image.
             if ( (_ttype == variables.hacktypes.glitch2m || _ttype == variables.hacktypes.devgl) &&
@@ -1048,21 +1036,6 @@ namespace JRunner.Classes
             string iniFilePath = "";
             string iniFileBackupPath = "";
             string[] iniFileContentsBackup = { };
-
-            // Type overrides, check doSomeChecks() if changing
-            if (_ttype == variables.hacktypes.glitch2 || _ttype == variables.hacktypes.glitch2m || _ttype == variables.hacktypes.devgl)
-            {
-                if (boardtype == "xenon")
-                {
-                    boardtype = "falcon";
-                    Console.WriteLine("Using Falcon type for Xenon");
-                }
-                else if (boardtype == "zephyr")
-                {
-                    boardtype = "falcon";
-                    Console.WriteLine("Using Falcon type for Zephyr");
-                }
-            }
 
             if (_ttype == variables.hacktypes.devgl)
             {
@@ -1275,9 +1248,9 @@ namespace JRunner.Classes
                     // For DevGL and Glitch2m, there is a bug in XeBuild that breaks falcon board types.
                     // To fix the image, we need to set the DWORD at 0x70 in NAND (the patch slot address)
                     // otherwise the CB/CD/CE patches won't be able to find the vfuses
-                    if(isAffectedByXeBuildFalconImageBug())
+                    if(isAffectedByXeBuildImageBug())
                     {
-                        Nand.Nand.fixPatchSlotSizeForFalconImage(Path.Combine(variables.xefolder, variables.updflash));
+                        Nand.Nand.fixPatchSlotSizeForBuggyImage(Path.Combine(variables.xefolder, variables.updflash));
                     }
 
                     if (_xdkbuild && _rgh3)

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -2129,7 +2129,7 @@ namespace JRunner
                 }
 
                 // Elpis CB_B for Xenon consoles with CB 73xx
-                if( nand.bl.CB_A >= 7373 && nand.bl.CB_A <= 7378 )
+                if( nand.bl.CB_B >= 7373 && nand.bl.CB_B <= 7378 )
                 {
                     xPanel.setElpisChecked(true);
                 }
@@ -3313,15 +3313,30 @@ namespace JRunner
                 return;
             }
 
-            if (Nand.Nand.VerifyKey(Oper.StringToByteArray(variables.cpukey)))
+            if (!Nand.Nand.VerifyKey(Oper.StringToByteArray(variables.cpukey)))
             {
-                if (nand.cpukeyverification(variables.cpukey))
-                {
-                    rgh3Build.create(variables.boardtype, variables.cpukey);
-                }
-                else Console.WriteLine("Wrong CPU Key");
+                Console.WriteLine("Bad CPU Key");
+                return;
             }
-            else Console.WriteLine("Bad CPU Key");
+
+            if (!nand.cpukeyverification(variables.cpukey))
+            {
+                Console.WriteLine("Wrong CPU Key");
+                return;
+            }
+
+            if (xPanel.getRbtnGlitch2mChecked())
+            {
+                // MFG loaders and by extension Glitch2m images encrypt the CB_B differently
+                // than retail CB_B, so we need to use a zero CPU key for invoking rgh3build
+                rgh3Build.create(variables.boardtype, "00000000000000000000000000000000");
+            }
+            else
+            {
+                rgh3Build.create(variables.boardtype, variables.cpukey);
+            }
+
+            
         }
 
         CustomXeBuild CX;

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2965,7 +2965,7 @@ namespace JRunner.Nand
         /// use patch slots so the bug didn't really appear before now.
         /// </summary>
         /// <param name="flashFilePath">Flash image to be patched, result will be written back to the same file</param>
-        public static void fixPatchSlotSizeForBuggyImage(string flashFilePath)
+        public static void fixBuggyXeBuildImage(string flashFilePath)
         {
             byte[] flashData = { };
 
@@ -2976,6 +2976,8 @@ namespace JRunner.Nand
 
             int blockType = 0;
             bool flashHasEcc = false;
+
+            Console.WriteLine("Patching image to resolve xeBuild bugs...");
 
             // Read in the flash image
             try
@@ -3031,10 +3033,27 @@ namespace JRunner.Nand
 
             // Set the patch slot size to 0x00010000, which is the same for all other
             // image types and glitch2m/DevGL on other board types
-            nandPatchPages[0x70] = 0x00;
-            nandPatchPages[0x71] = 0x01;
-            nandPatchPages[0x72] = 0x00;
-            nandPatchPages[0x73] = 0x00;
+            if( 0 == BitConverter.ToInt32(nandPatchPages.Skip(0x70).Take(0x4).ToArray(),0) )
+            {
+                Console.WriteLine("Fixing patch slot size set to zero...");
+
+                nandPatchPages[0x70] = 0x00;
+                nandPatchPages[0x71] = 0x01;
+                nandPatchPages[0x72] = 0x00;
+                nandPatchPages[0x73] = 0x00;
+            }
+
+
+            // Set the KV size to 0x00004000 (this is assuming a retail KV)
+            if (0 == BitConverter.ToInt32(nandPatchPages.Skip(0x60).Take(0x4).ToArray(), 0))
+            {
+                Console.WriteLine("Fixing KV size set to zero...");
+
+                nandPatchPages[0x60] = 0x00;
+                nandPatchPages[0x61] = 0x00;
+                nandPatchPages[0x62] = 0x40;
+                nandPatchPages[0x63] = 0x00;
+            }
 
             // Re-add ECC data and copy it over to the flash data buffer
             if (flashHasEcc)
@@ -3055,7 +3074,7 @@ namespace JRunner.Nand
                 return;
             }
 
-            Console.WriteLine("Successfully set patch slot size at 0x70");
+            Console.WriteLine("Successfully patched image!");
             Console.WriteLine("");
         }
 

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2965,7 +2965,7 @@ namespace JRunner.Nand
         /// use patch slots so the bug didn't really appear before now.
         /// </summary>
         /// <param name="flashFilePath">Flash image to be patched, result will be written back to the same file</param>
-        public static void fixPatchSlotSizeForFalconImage(string flashFilePath)
+        public static void fixPatchSlotSizeForBuggyImage(string flashFilePath)
         {
             byte[] flashData = { };
 
@@ -2984,7 +2984,7 @@ namespace JRunner.Nand
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Glitch2m/DevGL Falcon patch error: couldn't read input flash image");
+                Console.WriteLine("Glitch2m/DevGL image patch error: couldn't read input flash image");
                 if (variables.debugMode) Console.WriteLine(ex.ToString());
                 return;
             }
@@ -3002,7 +3002,7 @@ namespace JRunner.Nand
             }
             else
             {
-                Console.WriteLine("Glitch2m/DevGL Falcon patch error: invalid image size");
+                Console.WriteLine("Glitch2m/DevGL image patch error: invalid image size");
                 return;
             }
 
@@ -3050,12 +3050,12 @@ namespace JRunner.Nand
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Glitch2m/DevGL Falcon patch error: couldn't write output flash image");
+                Console.WriteLine("Glitch2m/DevGL image patch error: couldn't write output flash image");
                 if (variables.debugMode) Console.WriteLine(ex.ToString());
                 return;
             }
 
-            Console.WriteLine("Successfully patched Falcon image at 0x70");
+            Console.WriteLine("Successfully set patch slot size at 0x70");
             Console.WriteLine("");
         }
 

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -322,7 +322,7 @@ namespace JRunner.Panels
             chkAudClamp.Visible = rbtnJtag.Checked;
             chkRJtag.Visible = rbtnJtag.Checked;
             chk0Fuse.Visible = rbtnDevGL.Checked;
-            chkElpis.Visible = rbtnGlitch2.Checked;
+            chkElpis.Visible = rbtnGlitch2.Checked || rbtnGlitch2m.Checked;
 
             checkWBXdkBuild();
             checkBigffs(variables.boardtype);
@@ -1505,7 +1505,7 @@ namespace JRunner.Panels
                 {
                     File.Copy(Path.Combine(variables.rootfolder, @"xebuild\options.ini"), Path.Combine(variables.rootfolder, @"xebuild\data\options.ini"), true);
                     chkXeSettings.Checked = false;
-                    File.Move(Path.Combine(variables.xefolder, variables.updflash + ".log"), Path.Combine(variables.xefolder, variables.updflash.Substring(0, variables.updflash.IndexOf(".")) + "(" + DateTime.Now.ToString("ddMMyyyyHHmm") + ").bin.log"));
+                    File.Move(Path.Combine(variables.xefolder, variables.updflash + ".log"), Path.Combine(variables.xefolder, variables.updflash.Substring(0, variables.updflash.IndexOf(".")) + "(" + DateTime.Now.ToString("ddMMyyyyHHmmss") + ").bin.log"));
                 }
                 catch (Exception ex) { if (variables.debugMode) Console.WriteLine(ex.ToString()); }
             }


### PR DESCRIPTION
Using the falcon board type for xenon/zephyr/falcon causes a number of headaches because we're stuck with the falcon CB_B, namely:

- Falcon CB_B takes longer to do HWINIT = system takes a longer to boot than needed
- Falcon CB_B doesn't support the samsung + elpis combo
- Prevents us from doing board specific patches, e.g. booting 1888 on a falcon requires different patches than a jasper or xenon.

Removing this restriction will allow the use of different patches per board, and with the work going on in https://github.com/wurthless-elektroniks/modern-loadfare we should eventually be able to use any CB_B version we wish

Note: this will require a reorg of the ini files and patch sets for xenon/zephyr, i'll open a PR to the files repository shortly that will build images equivalent to the current patch sets. We can test updated patches later.


This PR also has some additional changes:

- Rename isAffectedByXeBuildFalconImageBug to isAffectedByXeBuildImageBug -> Xenon and Zephyr image types are also affected by the same issue
- Check CB_B version for setting the elpis checkbox -> glitch2/glitch2m images don't use 7378 CB_A, they use 5772 and 9188mfg respectively
- Fix the manual RGH3 conversion button so it works with glitch2m images
- Show the elpis checkbox when glitch2m is selected
- Add "seconds" to the name of the updflash.bin log file, i was getting exceptions when i'd re-build an image within the minute with different settings
