### PR TITLE
Dont patch the SMC reset limit if it's not a glitch image type

### DIFF
--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -917,6 +917,22 @@ namespace JRunner.Classes
             {
                 File.Copy(Path.Combine(variables.rootfolder, @"xebuild\options.ini"), Path.Combine(variables.rootfolder, @"xebuild\data\options.ini"), true);
             }
+
+            // Don't patch the SMC reset limit if it's not a glitch
+            // type image. JTAG doesn't reset the processor
+            // and DevGL/Devkit/Testkit/Retail images boot directly
+            // in to the kernel so if it takes more than one try
+            // and the SMC is resetting, something is wrong and
+            // we should be getting a red ring of some sort
+            if( ! (_ttype == variables.hacktypes.glitch||
+                   _ttype == variables.hacktypes.glitch2||
+                   _ttype == variables.hacktypes.glitch2m) )
+            {
+                string[] dontPatchSmc = { "patchsmc=false" };
+                string[] delete = { };
+                parse_ini.edit_ini(Path.Combine(variables.rootfolder, @"xeBuild\data\options.ini"), dontPatchSmc, delete);
+            }
+
         }
 
         public XebuildError createxebuild(bool custom)


### PR DESCRIPTION
I don't know why, but xeBuild thinks it's a good idea to patch the SMC reset limit even for situations where it doesn't make sense, i.e. DevGL, JTAG, etc. where if the SMC thinks it's a good idea to reset the processor at all you've got a legitimate problem.

I'd argue the SMC reset limit isn't needed for glitch images either, but some people do bad installs or have early RGH versions that take many tries to boot.

As such, this PR will automatically edit the ini used for the xeBuild session to set `patchsmc=false` when the image type isn't glitch, glitch2, or glitch2m