### PR TITLE
Add an option for overclocked RGH3 + Inject XeLL for ECCs

### DIFF
--- a/J-Runner/Classes/rgh3build.cs
+++ b/J-Runner/Classes/rgh3build.cs
@@ -17,7 +17,7 @@ namespace JRunner
             string mhz = "";
             if (sequenced)
             {
-                if (MainForm.mainForm.xPanel.getRgh3Mhz() != "27") mhz = MainForm.mainForm.xPanel.getRgh3Mhz();
+                if (MainForm.mainForm.xPanel.getRgh3Mhz() != "27") mhz = "_" + MainForm.mainForm.xPanel.getRgh3Mhz();
             }
 
             if (board == "Corona 4GB") ecc = variables.RGH3_corona4gb;

--- a/J-Runner/Classes/rgh3build.cs
+++ b/J-Runner/Classes/rgh3build.cs
@@ -17,7 +17,7 @@ namespace JRunner
             string mhz = "";
             if (sequenced)
             {
-                if (MainForm.mainForm.xPanel.getRgh3Mhz() == 10) mhz = "_10";
+                if (MainForm.mainForm.xPanel.getRgh3Mhz() != "27") mhz = MainForm.mainForm.xPanel.getRgh3Mhz();
             }
 
             if (board == "Corona 4GB") ecc = variables.RGH3_corona4gb;

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -2303,7 +2303,7 @@ namespace JRunner
             if (xPanel.getRgh3Checked())
             {
                 string mhz = "";
-                if (xPanel.getRgh3Mhz() != "27") mhz = xPanel.getRgh3Mhz();
+                if (xPanel.getRgh3Mhz() != "27") mhz = "_" + xPanel.getRgh3Mhz();
 
                 switch (variables.ctype.ID)
                 {

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -2303,7 +2303,7 @@ namespace JRunner
             if (xPanel.getRgh3Checked())
             {
                 string mhz = "";
-                if (xPanel.getRgh3Mhz() == 10) mhz = "_10";
+                if (xPanel.getRgh3Mhz() != "27") mhz = xPanel.getRgh3Mhz();
 
                 switch (variables.ctype.ID)
                 {

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2843,11 +2843,11 @@ namespace JRunner.Nand
             xellPageCount = xellData.Length / pagesz;
 
             // Determine whether this image has ECC
-            if (flashData.Length == 17301504 || flashData.Length == 69206016)
+            if (flashData.Length == 17301504 || flashData.Length == 69206016 || flashData.Length == 1351680 )
             {
                 flashHasEcc = true;
             }
-            else if (flashData.Length == 50331648)
+            else if (flashData.Length == 50331648 || flashData.Length == 1310720 )
             {
                 flashHasEcc = false;
             }
@@ -2904,50 +2904,49 @@ namespace JRunner.Nand
                 {
                     xellOffset = testXellOffset;
                     Console.WriteLine("XeLL found at offset 0x" + xellOffset.ToString("x"));
-                    break;
+
+                    if (0 != xellOffsetInPage)
+                    {
+                        // If XeLL is not stored on a page boundary (thank you JTAG)
+                        // then we need to read one more page from the flash data
+                        xellPageCount += 1;
+                    }
+
+                    if (flashHasEcc)
+                    {
+                        // Get the physical pages from the flash image that we need to modify
+                        byte[] xellFlashPages = flashData.Skip(xellFirstPageOffsetPhys).Take(xellPageCount * pagesz_phys).ToArray();
+
+                        // Strip the ECC data
+                        xellFlashPages = unecc(xellFlashPages);
+
+                        // Copy the xell data into the pages
+                        Buffer.BlockCopy(xellData, 0, xellFlashPages, xellOffsetInPage, xellData.Length);
+
+                        // Re-add ECC data
+                        xellFlashPages = addecc_v2(xellFlashPages, true, xellPageNumber * pagesz_phys, blockType);
+
+                        // Copy the ECC'ed pages back to the NAND image
+                        Buffer.BlockCopy(xellFlashPages, 0, flashData, xellFirstPageOffsetPhys, xellFlashPages.Length);
+                    }
+                    else
+                    {
+                        // We can just do a plain copy if there's no ECC data
+                        Buffer.BlockCopy(xellData, 0, flashData, xellOffset, xellData.Length);
+                    }
+
+                    // Do a final sanity check to make sure something didn't go wrong
+                    if (!Oper.ByteArrayCompare(flashData, Oper.StringToByteArray("48000020480000EC4800000048000000"), xellOffsetPhys, 0, 0x10))
+                    {
+                        Console.WriteLine("Couldn't inject XeLL: couldn't detect XeLL in the resulting flash image");
+                        return;
+                    }
                 }
             }
 
             if( 0 == xellOffset )
             {
                 Console.WriteLine("Couldn't inject XeLL: did not find XeLL in this flash image");
-                return;
-            }
-
-            if ( 0 != xellOffsetInPage )
-            {
-                // If XeLL is not stored on a page boundary (thank you JTAG)
-                // then we need to read one more page from the flash data
-                xellPageCount += 1;
-            }
-
-            if( flashHasEcc )
-            {
-                // Get the physical pages from the flash image that we need to modify
-                byte[] xellFlashPages = flashData.Skip(xellFirstPageOffsetPhys).Take(xellPageCount * pagesz_phys).ToArray();
-
-                // Strip the ECC data
-                xellFlashPages = unecc(xellFlashPages);
-
-                // Copy the xell data into the pages
-                Buffer.BlockCopy(xellData, 0, xellFlashPages, xellOffsetInPage, xellData.Length);
-
-                // Re-add ECC data
-                xellFlashPages = addecc_v2(xellFlashPages, true, xellPageNumber * pagesz_phys, blockType);
-
-                // Copy the ECC'ed pages back to the NAND image
-                Buffer.BlockCopy(xellFlashPages, 0, flashData, xellFirstPageOffsetPhys, xellFlashPages.Length);
-            }
-            else
-            {
-                // We can just do a plain copy if there's no ECC data
-                Buffer.BlockCopy(xellData,0,flashData,xellOffset,xellData.Length);
-            }
-
-            // Do a final sanity check to make sure something didn't go wrong
-            if (!Oper.ByteArrayCompare(flashData, Oper.StringToByteArray("48000020480000EC4800000048000000"), xellOffsetPhys, 0, 0x10))
-            {
-                Console.WriteLine("Couldn't inject XeLL: couldn't detect XeLL in the resulting flash image");
                 return;
             }
 

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -136,9 +136,9 @@ namespace JRunner.Panels
         {
             return chkRgh3.Checked;
         }
-        public int getRgh3Mhz()
+        public string getRgh3Mhz()
         {
-            return int.Parse(Rgh3Mhz.Text);
+            return Rgh3Mhz.Text;
         }
         public bool getAudClampChecked()
         {

--- a/J-Runner/Panels/XeBuildPanel.designer.cs
+++ b/J-Runner/Panels/XeBuildPanel.designer.cs
@@ -214,7 +214,8 @@
             this.Rgh3Mhz.FormattingEnabled = true;
             this.Rgh3Mhz.Items.AddRange(new object[] {
             "10",
-            "27"});
+            "27",
+            "OC"});
             this.Rgh3Mhz.Location = new System.Drawing.Point(284, 61);
             this.Rgh3Mhz.Name = "Rgh3Mhz";
             this.Rgh3Mhz.Size = new System.Drawing.Size(36, 21);


### PR DESCRIPTION
This PR adds an option for the overclocked RGH3 for falcon and jasper. It does not change the default from the 27mhz version (should we consider doing that?).

This PR also updates InjectXeLL so that it can update images with multiple copies of Xell (aka these ECCs, so the ECCs don't need to be regenerated from scratch)