### PR TITLE
XeBuild bug affects retail too

### DIFF
--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -1029,7 +1029,7 @@ namespace JRunner.Classes
             // If we've selected the following options, we're building an image
             // that is affected by a bug in XeBuild that doesn't set the patch slot
             // size correctly and need to patch the resulting image.
-            if ( (_ttype == variables.hacktypes.glitch2m || _ttype == variables.hacktypes.devgl) &&
+            if ( (_ttype == variables.hacktypes.retail || _ttype == variables.hacktypes.glitch2m || _ttype == variables.hacktypes.devgl) &&
                  ( _ctype.ID == 2 || _ctype.ID == 3 || _ctype.ID == 8 ) )
             {
                 return true;

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -2985,7 +2985,7 @@ namespace JRunner.Nand
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Glitch2m/DevGL image patch error: couldn't read input flash image");
+                Console.WriteLine("Image patch error: couldn't read input flash image");
                 if (variables.debugMode) Console.WriteLine(ex.ToString());
                 return;
             }
@@ -3003,7 +3003,7 @@ namespace JRunner.Nand
             }
             else
             {
-                Console.WriteLine("Glitch2m/DevGL image patch error: invalid image size");
+                Console.WriteLine("Image patch error: invalid image size");
                 return;
             }
 
@@ -3068,7 +3068,7 @@ namespace JRunner.Nand
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Glitch2m/DevGL image patch error: couldn't write output flash image");
+                Console.WriteLine("Image patch error: couldn't write output flash image");
                 if (variables.debugMode) Console.WriteLine(ex.ToString());
                 return;
             }


### PR DESCRIPTION
XeBuild has a bug where the patch slot size and KV size are set to zero for xenon/zephyr/falcon

I discovered today that retail images are affected as well, in addition to glitch2m and devGL. This PR makes JRunner call the patch slot size and kv size check/fix routine for retail images.