### PR TITLE
Rgh3 related fixes

### DIFF
--- a/J-Runner/Classes/RGH2to3.cs
+++ b/J-Runner/Classes/RGH2to3.cs
@@ -397,6 +397,34 @@ namespace JRunner.Classes
                     if(flashHasEcc)
                         patchFlashData = UnEcc(patchFlashData);
                 }
+                else if (loaderName == "CD")
+                {
+                    // SE
+                    loaderName = ReadString(patchFlashData, (int)loaderOffs, 2);
+                    loaderVer = U16ReadBE(patchFlashData, (int)(loaderOffs + 2));
+                    loaderFlags = U32ReadBE(patchFlashData, (int)(loaderOffs + 4));
+                    loaderEntry = U32ReadBE(patchFlashData, (int)(loaderOffs + 8));
+                    loaderSize = U32ReadBE(patchFlashData, (int)(loaderOffs + 12));
+                    loaderOffs += loaderSize;
+
+                    if (loaderName == "SE")
+                    {
+                        // Extra Pages
+                        int numPages = (int)loaderOffs / 0x200;
+                        if (loaderOffs % 0x200 != 0)
+                            numPages += 1;
+                        numPages += 4;
+
+                        int flashEnd = numPages * (flashHasEcc ? 0x210 : 0x200);
+                        patchFlashData = flashData.Take(flashEnd).ToArray();
+                        if (flashHasEcc)
+                            patchFlashData = UnEcc(patchFlashData);
+                    }
+                    else
+                    {
+                        return RGH_CONVERT_ERROR.ERROR_XELL_NOT_FOUND;
+                    }
+                }
                 else
                 {
                     return RGH_CONVERT_ERROR.ERROR_XELL_NOT_FOUND;

--- a/J-Runner/Forms/EnterCPUKey.cs
+++ b/J-Runner/Forms/EnterCPUKey.cs
@@ -26,12 +26,14 @@ namespace JRunner.Forms
                                                   MessageBoxButtons.YesNo,
                                                   MessageBoxIcon.Warning);
 
-                if (dr == DialogResult.Yes)
+                if (dr != DialogResult.Yes)
                 {
-                    cpukey = txtCpuKey.Text;
-                    this.DialogResult = DialogResult.OK;
+                    return;
                 }
             }
+
+            cpukey = txtCpuKey.Text;
+            this.DialogResult = DialogResult.OK;
         }
 
         private void lblPhysicalCpuKey_DoubleClick(object sender, EventArgs e)

--- a/J-Runner/MainForm.Designer.cs
+++ b/J-Runner/MainForm.Designer.cs
@@ -110,8 +110,6 @@ namespace JRunner
             this.writeFusionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
             this.convertToRGH3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.g3fixToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.zeroPairSbToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.checkSecdataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.CustomXeBuildMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripSeparator();
@@ -176,6 +174,10 @@ namespace JRunner
             this.jRPBLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateJRPToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.keyDatabaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.experimentalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.g3fixToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.zeroPairSbToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.groupBox8.SuspendLayout();
             this.getCpuKeyMenu.SuspendLayout();
             this.showWorkingFolderMenu.SuspendLayout();
@@ -851,14 +853,14 @@ namespace JRunner
             this.writeFusionToolStripMenuItem,
             this.toolStripMenuItem1,
             this.convertToRGH3ToolStripMenuItem,
-            this.g3fixToolStripMenuItem,
-            this.zeroPairSbToolStripMenuItem,
             this.checkSecdataToolStripMenuItem,
             this.CustomXeBuildMenuItem,
             this.toolStripMenuItem5,
             this.hexEditorToolStripMenuItem,
             this.kVViewerToolStripMenuItem,
-            this.generateCpuKeyToolStripMenuItem});
+            this.generateCpuKeyToolStripMenuItem,
+            this.toolStripSeparator1,
+            this.experimentalToolStripMenuItem});
             this.advancedToolStripMenuItem.Name = "advancedToolStripMenuItem";
             this.advancedToolStripMenuItem.Size = new System.Drawing.Size(72, 20);
             this.advancedToolStripMenuItem.Text = "Advanced";
@@ -898,20 +900,6 @@ namespace JRunner
             this.convertToRGH3ToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
             this.convertToRGH3ToolStripMenuItem.Text = "Convert to RGH3";
             this.convertToRGH3ToolStripMenuItem.Click += new System.EventHandler(this.convertToRGH3ToolStripMenuItem_Click);
-            // 
-            // g3fixToolStripMenuItem
-            // 
-            this.g3fixToolStripMenuItem.Name = "g3fixToolStripMenuItem";
-            this.g3fixToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
-            this.g3fixToolStripMenuItem.Text = "G3fix patch";
-            this.g3fixToolStripMenuItem.Click += new System.EventHandler(this.g3fixToolStripMenuItem_Click);
-            // 
-            // zeroPairSbToolStripMenuItem
-            // 
-            this.zeroPairSbToolStripMenuItem.Name = "zeroPairSbToolStripMenuItem";
-            this.zeroPairSbToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
-            this.zeroPairSbToolStripMenuItem.Text = "Zero pair SB";
-            this.zeroPairSbToolStripMenuItem.Click += new System.EventHandler(this.zeroPairSbToolStripMenuItem_Click);
             // 
             // checkSecdataToolStripMenuItem
             // 
@@ -1436,6 +1424,34 @@ namespace JRunner
             this.keyDatabaseToolStripMenuItem.Text = "Key Database";
             this.keyDatabaseToolStripMenuItem.Click += new System.EventHandler(this.keyDatabaseToolStripMenuItem_Click);
             // 
+            // experimentalToolStripMenuItem
+            // 
+            this.experimentalToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.g3fixToolStripMenuItem,
+            this.zeroPairSbToolStripMenuItem});
+            this.experimentalToolStripMenuItem.Name = "experimentalToolStripMenuItem";
+            this.experimentalToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
+            this.experimentalToolStripMenuItem.Text = "Experimental Features";
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(237, 6);
+            // 
+            // g3fixToolStripMenuItem
+            // 
+            this.g3fixToolStripMenuItem.Name = "g3fixToolStripMenuItem";
+            this.g3fixToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.g3fixToolStripMenuItem.Text = "G3fix patch";
+            this.g3fixToolStripMenuItem.Click += new System.EventHandler(this.g3fixToolStripMenuItem_Click);
+            // 
+            // zeroPairSbToolStripMenuItem
+            // 
+            this.zeroPairSbToolStripMenuItem.Name = "zeroPairSbToolStripMenuItem";
+            this.zeroPairSbToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.zeroPairSbToolStripMenuItem.Text = "Zero pair SB";
+            this.zeroPairSbToolStripMenuItem.Click += new System.EventHandler(this.zeroPairSbToolStripMenuItem_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1620,7 +1636,6 @@ namespace JRunner
         private ToolStripMenuItem createSafeDualImageToolStripMenuItem;
         private ToolStripMenuItem nANDAlignmentToolStripMenuItem;
         private ToolStripMenuItem gB16MBToolStripMenuItem;
-        private ToolStripMenuItem zeroPairSbToolStripMenuItem;
         private ToolStripMenuItem mB64MBToolStripMenuItem;
         private ToolStripMenuItem addressCalculatorToolStripMenuItem;
         private ToolStripMenuItem keyvaultOptionsToolStripMenuItem;
@@ -1631,6 +1646,9 @@ namespace JRunner
         private ToolStripMenuItem loadGlitch2XeLLToolStripMenuItem;
         private ToolStripMenuItem loadJTAGXeLLToolStripMenuItem;
         private ToolStripMenuItem injectXeLLToolStripMenuItem;
+        private ToolStripSeparator toolStripSeparator1;
+        private ToolStripMenuItem experimentalToolStripMenuItem;
         private ToolStripMenuItem g3fixToolStripMenuItem;
+        private ToolStripMenuItem zeroPairSbToolStripMenuItem;
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3267,6 +3267,15 @@ namespace JRunner
                 return;
             }
 
+            if (mainForm.xPanel.getRgh3Mhz() == "OC")
+            {
+                if (MessageBox.Show("G3fix is currently not supported with the overclocked RGH3 ECC.\n\nContinuing will produce an image that is likely unbootable.\n\nDo you want to continue?", "Steep Hill Ahead", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.No)
+                {
+                    Console.WriteLine("g3fix error: Please create an RGH3 image with the 27mhz or 10mhz option selected.");
+                    return;
+                }
+            }
+
             if (Nand.Nand.g3fixDoesSourceNandContainVfuses(variables.filename1))
             {
                 EnterCPUKey ecpuDialog = new EnterCPUKey();

--- a/J-Runner/MainForm.resx
+++ b/J-Runner/MainForm.resx
@@ -120,6 +120,9 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>917, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>917, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnIPGetCPU.BtnImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
- Fix the g3fix CPU key prompt when the CPU key is actually valid (was only testing this on the fffalcon until now)
- Move the g3fix and zero pair SB menu items under "experimental features"
- Add a warning for g3fix (only works with the non-OC SMC atm)
- add support for RGLoader style images to RGH2to3 (CB->CD->SE)