### PR TITLE
Allow XDKBuild to run for other dashboards than 17489

### DIFF
--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -588,7 +588,7 @@ namespace JRunner.Panels
         bool chkWB4GEn = true;
         public void checkWBXdkBuild()
         {
-            if ( (rbtnGlitch2m.Checked || rbtnDevGL.Checked) && variables.dashversion.Equals("17489") && File.Exists(variables.rootfolder + @"\xeBuild\17489\!XDKbuild Only!.txt"))
+            if ( (rbtnGlitch2m.Checked || rbtnDevGL.Checked) && File.Exists(variables.rootfolder + @"\xeBuild\" + variables.dashversion + @"\!XDKbuild Only!.txt"))
             {
                 chkWB.Visible = false;
                 chkWB.Checked = false;


### PR DESCRIPTION
Remove the dashboard version number check for XDKBuild, leaving only the magic text file as a flag to enable XDKBuild.

All XDKBuild really does is inject SC 17489, so if a given image is build with CB_A -> SB -> SD like regular XDKBuild, then we can use the XDKBuild post-build step just the same.

I used this to build an RGLoader image that actually works on RGH3 (and presumably regular glitch2m as well)

Need to merge this as well so XDKbuild knows what SC to inject for xenon/zephyr https://github.com/Pheeeeenom/J-Runner-with-Extras-Files/pull/7