### PR TITLE
Fix for xsvftool path name

### DIFF
--- a/J-Runner/Classes/xFlasher.cs
+++ b/J-Runner/Classes/xFlasher.cs
@@ -1026,7 +1026,7 @@ namespace JRunner
                     {
                         Console.WriteLine($"xFlasher: {dev} detected");
                         psi = new Process();
-                        psi.StartInfo.FileName = @"common/xsvftool/xsvftool.exe";
+                        psi.StartInfo.FileName = @"common/xsvftool/xsvftool-ftd2xx_x86.exe";
                         psi.StartInfo.Arguments = "-j 0 -p -f " + speed + (xsvf ? " -x" : " -s") + " \"" + MainForm.tempTimingPath + "\"";
                         psi.StartInfo.CreateNoWindow = true;
                         psi.StartInfo.UseShellExecute = false;


### PR DESCRIPTION
There are two calls to xsvftool, one call is missing the full name of the xsvftool executable. This is breaking glitch chip flashing atm. Flashing works with this fix.