### PR TITLE
Allow parsing of early NAND images that have different header magic bytes

### DIFF
--- a/J-Runner/Classes/xdkbuild.cs
+++ b/J-Runner/Classes/xdkbuild.cs
@@ -68,7 +68,11 @@ namespace JRunner
                     pProcess.CancelOutputRead();
                     Console.WriteLine("XDKbuild Conversion Finished!");
                     Console.WriteLine("Remember to program a compatible timing file!");
-                    if (!notlast) MainForm.mainForm.xPanel.xeExitActual();
+                    if (!notlast)
+                    {
+                        variables.xefinished = true;
+                        MainForm.mainForm.xPanel.xeExitActual();
+                    }
                 }
             }
             catch (Exception objException)

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -223,9 +223,11 @@ namespace JRunner.Nand
             }
             //
 
-            // Early NAND images begin with 0x0F3F
+            // Early NAND images begin with 0x0F3F or 0x0F4F
             // Regular NAND images begin with 0xFF4F
-            if ( (data[0] == 0xFF && data[1] == 0x4F) || (data[0] == 0x0F && data[1] == 0x3F) )
+            if ( (data[0] == 0xFF && data[1] == 0x4F) ||
+                 (data[0] == 0x0F && data[1] == 0x3F) ||
+                 (data[0] == 0x0F && data[1] == 0x4F) )
             {
                 unpack_base_image(data, bigblock);
 

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -223,7 +223,9 @@ namespace JRunner.Nand
             }
             //
 
-            if (data[0] == 0xFF && data[1] == 0x4F)
+            // Early NAND images begin with 0x0F3F
+            // Regular NAND images begin with 0xFF4F
+            if ( (data[0] == 0xFF && data[1] == 0x4F) || (data[0] == 0x0F && data[1] == 0x3F) )
             {
                 unpack_base_image(data, bigblock);
 

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -318,10 +318,19 @@ namespace JRunner.Nand
 
                 for (block = 0; block < 30; block++)
                 {
-                    // Dev BLs start with 0x53 (S)
-                    isDevBl = (image[block_offset_b] == 0x53);
+                    // Dev BLs start with characters other than 0x43 (C)
+                    isDevBl = (image[block_offset_b] != 0x43);
+
                     // Get the ID string of the BL (CB/CD/SB/SD/etc)
                     blIdString = Encoding.ASCII.GetString(image.Skip(block_offset_b).Take(2).ToArray());
+
+                    // If the first character of the ID string is garbage, it's an old dev bootloader
+                    // Replace it with an S character
+                    if (Path.GetInvalidFileNameChars().Contains(blIdString[0]))
+                    {
+                        blIdString = "S" + blIdString.Substring(1);
+                    }
+
                     block_id = image[block_offset_b + 1];
                     Buffer.BlockCopy(image, block_offset_b + 2, block_build_b, 0, 2);
                     //block_build_b = returnportion(image, block_offset_b + 2, 2);
@@ -338,7 +347,7 @@ namespace JRunner.Nand
                         break;
                     }
 
-                    if (variables.debugMode) Console.WriteLine("Found {0}BL (build {1}) at {2}", id, block_build, Convert.ToString(block_offset_b, 16));
+                    if (variables.debugMode) Console.WriteLine("Found {0} {1}BL (build {2}) at {3}", isDevBl ? "dev" : "retail", id, block_build, Convert.ToString(block_offset_b, 16));
                     data = new byte[block_size];
                     //data = returnportion(image, block_offset_b, block_size);
                     if (block_offset_b + block_size <= image.Length) Buffer.BlockCopy(image, block_offset_b, data, 0, block_size);
@@ -448,7 +457,7 @@ namespace JRunner.Nand
                     if (variables.extractfiles) Oper.savefile(sc_dec, "output\\" + bl._3BL_magic + "_dec.bin");
                 }
 
-                if (bl.CD > 0)
+                if (bl._4BL_magic != "")
                 {
 
                     if (variables.extractfiles) Oper.savefile(CD, "output\\" + bl._4BL_magic + ".bin");

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -332,6 +332,12 @@ namespace JRunner.Nand
                     block_size += 0xF;
                     block_size &= ~0xF;
                     id = block_id & 0xF;
+
+                    if (id == 0 || block_size == 0)
+                    {
+                        break;
+                    }
+
                     if (variables.debugMode) Console.WriteLine("Found {0}BL (build {1}) at {2}", id, block_build, Convert.ToString(block_offset_b, 16));
                     data = new byte[block_size];
                     //data = returnportion(image, block_offset_b, block_size);

--- a/J-Runner/Panels/NandInfo.cs
+++ b/J-Runner/Panels/NandInfo.cs
@@ -148,7 +148,7 @@ namespace JRunner.Panels
                         textBoxCBX.Visible = false;
                     }
 
-                    if (nand.bl.CD > 0)
+                    if (nand.bl._4BL_magic != "")
                     {
                         label4bl.Text = nand.bl._4BL_magic;
                         textBox4BL.Text = nand.bl.CD.ToString();


### PR DESCRIPTION
Early NAND images have different magic bytes. Only thing that prevents J-Runner from parsing such images is the magic byte check in `Nand.cs`. Everything else works as-is, the bootloaders and KV are decrypted and extracted properly.