### PR TITLE
Don't enforce KV size check if the size in the header is 0

### DIFF
--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -1420,7 +1420,11 @@ namespace JRunner.Nand
                 return;
             }
 
-            if (kvFileData.Length != flashKvSize)
+            if (flashKvSize == 0)
+            {
+                Console.WriteLine("Warning: KV size set to 0 in this flash image. KV size will not be validated.");
+            }
+            else if (kvFileData.Length != flashKvSize)
             {
                 Console.WriteLine("Error: can't inject a different length KV in to an existing NAND");
                 return;


### PR DESCRIPTION
When the KV injection feature was created, there was a size check to validate that you weren't injecting a dev KV on a retail image, and vice versa.

However, it seems there are a lot of images floating around where the KV size is set to 0 (retail type 1 images are like this it seems) and xeBuild doesn't set it for most xenon images.

To make it so this feature is actually useful for xenon type 1, print a warning rather than an error if the KV size in the flash header is set to 0.