### PR TITLE
Read CPU Key from virtual fuses in a NAND dump

### DIFF
--- a/J-Runner/Classes/NativeMethods.cs
+++ b/J-Runner/Classes/NativeMethods.cs
@@ -9,7 +9,7 @@ namespace JRunner
         public const int HWND_BROADCAST = 0xffff;
         public static readonly int WM_SHOWAPP = RegisterWindowMessage("WM_SHOWAPP");
         [DllImport("user32")]
-        public static extern bool SendMessage(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
+        public static extern bool PostMessage(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam);
         [DllImport("user32")]
         public static extern int RegisterWindowMessage(string message);
     }

--- a/J-Runner/Classes/Program.cs
+++ b/J-Runner/Classes/Program.cs
@@ -152,7 +152,7 @@ namespace JRunner
                     if (process.Id != current.Id)
                     {
                         found = true;
-                        NativeMethods.SendMessage(
+                        NativeMethods.PostMessage(
                             (IntPtr)NativeMethods.HWND_BROADCAST,
                             NativeMethods.WM_SHOWAPP,
                             IntPtr.Zero,

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -1899,6 +1899,9 @@ namespace JRunner
 
                 bool sts = objAlphaPattern.IsMatch(variables.cpukey);
 
+                byte[] cpukeyArr = { };
+                bool nandContainsVfuses = Nand.Nand.getVirtualCPUKey(variables.filename1, ref cpukeyArr);
+
                 string cpufile = Path.Combine(Path.GetDirectoryName(variables.filename1), "cpukey.txt");
                 if (File.Exists(cpufile) && !(variables.cpukey.Length == 32 && sts))
                 {
@@ -1906,6 +1909,19 @@ namespace JRunner
                 }
 
                 if (variables.cpukey.Length != 32 || !objAlphaPattern.IsMatch(variables.cpukey)) variables.cpukey = "";
+
+                if (nandContainsVfuses)
+                {
+                    string cpukeyStr = Oper.ByteArrayToString(cpukeyArr);
+
+                    if (variables.debugMode) Console.WriteLine("Virtual CPU Key: " + cpukeyStr);
+
+                    // If we didn't set the CPU key yet, use the virtual CPU key from the NAND dump
+                    if (variables.cpukey == "")
+                    {
+                        variables.cpukey = cpukeyStr;
+                    }
+                }
 
                 bool foundKey = !string.IsNullOrEmpty(variables.cpukey);
                 bool gotKeyFromCrc = false;
@@ -2024,7 +2040,7 @@ namespace JRunner
                             break;
                         case variables.hacktypes.glitch2:
                             // If the source NAND image contains a virtual fuse set, select glitch2m
-                            if (Nand.Nand.doesNandContainVfuses(variables.filename1))
+                            if (nandContainsVfuses)
                             {
                                 xPanel.BeginInvoke(new Action(() => xPanel.setRbtnGlitch2mChecked(true)));
                             }

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -3413,6 +3413,12 @@ namespace JRunner.Nand
 
         public static bool doesNandContainVfuses(string flashFilePath)
         {
+            byte[] cpukeyArr = { };
+            return getVirtualCPUKey(flashFilePath, ref cpukeyArr);
+        }
+
+        public static bool getVirtualCPUKey(string flashFilePath, ref byte[] cpukey)
+        {
             byte[] flashData = { };
             byte[] fuseline0 = { 0xC0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
             bool flashHasEcc = true;
@@ -3476,8 +3482,18 @@ namespace JRunner.Nand
                 if (Oper.ByteArrayCompare(fuseline0, flashData.Skip(patchSlotAddressPhys).Take(0x8).ToArray(), 0x8))
                 {
                     // ByteArrayCompare returns true if the buffers are equal
+                    cpukey = flashData.Skip(patchSlotAddressPhys + 0x20).Take(0x10).ToArray();
                     return true;
                 }
+            }
+
+            // If we didn't find virtual fuses in the regular locations, 
+            // try the JTAG location (0x95000 logical, 0x99A80 physical)
+            if (Oper.ByteArrayCompare(fuseline0, flashData.Skip(0x99A80).Take(0x8).ToArray(), 0x8))
+            {
+                // ByteArrayCompare returns true if the buffers are equal
+                cpukey = flashData.Skip(0x99A80 + 0x20).Take(0x10).ToArray();
+                return true;
             }
 
             return false;


### PR DESCRIPTION
JTAG and glitch2m images have a virtual fuse set in the NAND dump, in plain text. This virtual fuse set contains the CPU key needed to decrypt the KV and build a new NAND image. J-Runner already knows how to tell if an image has virtual fuses- this change makes it so JRunner grabs the CPU key from the NAND dump if virtual fuses are found in the usual locations.

I also ran in to an issue where i was getting a bunch of JRunner processes hung on SendMessage when trying to make an existing JRunner instance come to the foreground- changed it to PostMessage (which doesn't wait for a response) and the issue was resolved.