### PR TITLE
Add an "inject rgh1.3/rgh3 ECC" function under the experimental menu

### DIFF
--- a/J-Runner/Classes/rgh3build.cs
+++ b/J-Runner/Classes/rgh3build.cs
@@ -8,6 +8,26 @@ namespace JRunner
     {
         private string filename;
 
+        public void injectECC(string eccpath, string cpuKey)
+        {
+            Console.WriteLine("Injecting glitch3 ECC...");
+            Thread.Sleep(1000); // Important
+
+            try
+            {
+                Classes.RGH2to3.ConvertRgh2ToRgh3(eccpath, variables.filename1, cpuKey, variables.filename1);
+            }
+            catch (Exception ex)
+            {
+                if (variables.debugMode) Console.WriteLine(ex.ToString());
+                Console.WriteLine("Failed: The image is either already RGH 1.3, already RGH3, or an unsupported image type");
+                Console.WriteLine("");
+                return;
+            }
+
+            MainForm.mainForm.nand_init();
+        }
+
         public void create(string board, string cpuKey, bool sequenced = false)
         {
             Console.WriteLine("Converting Image to RGH3...");

--- a/J-Runner/MainForm.Designer.cs
+++ b/J-Runner/MainForm.Designer.cs
@@ -116,6 +116,11 @@ namespace JRunner
             this.hexEditorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.kVViewerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.generateCpuKeyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.experimentalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.g3fixToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.zeroPairSbToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.injectGlitch3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.jRPToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.powerOnToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.shutdownToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -174,10 +179,6 @@ namespace JRunner
             this.jRPBLToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.updateJRPToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.keyDatabaseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.experimentalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.g3fixToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.zeroPairSbToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.groupBox8.SuspendLayout();
             this.getCpuKeyMenu.SuspendLayout();
             this.showWorkingFolderMenu.SuspendLayout();
@@ -942,6 +943,42 @@ namespace JRunner
             this.generateCpuKeyToolStripMenuItem.ToolTipText = "Generates a valid CPU Key in the CPU Key box";
             this.generateCpuKeyToolStripMenuItem.Click += new System.EventHandler(this.generateCpuKeyToolStripMenuItem_Click);
             // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(237, 6);
+            // 
+            // experimentalToolStripMenuItem
+            // 
+            this.experimentalToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.g3fixToolStripMenuItem,
+            this.zeroPairSbToolStripMenuItem,
+            this.injectGlitch3ToolStripMenuItem});
+            this.experimentalToolStripMenuItem.Name = "experimentalToolStripMenuItem";
+            this.experimentalToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
+            this.experimentalToolStripMenuItem.Text = "Experimental Features";
+            // 
+            // g3fixToolStripMenuItem
+            // 
+            this.g3fixToolStripMenuItem.Name = "g3fixToolStripMenuItem";
+            this.g3fixToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            this.g3fixToolStripMenuItem.Text = "G3fix patch";
+            this.g3fixToolStripMenuItem.Click += new System.EventHandler(this.g3fixToolStripMenuItem_Click);
+            // 
+            // zeroPairSbToolStripMenuItem
+            // 
+            this.zeroPairSbToolStripMenuItem.Name = "zeroPairSbToolStripMenuItem";
+            this.zeroPairSbToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            this.zeroPairSbToolStripMenuItem.Text = "Zero pair SB";
+            this.zeroPairSbToolStripMenuItem.Click += new System.EventHandler(this.zeroPairSbToolStripMenuItem_Click);
+            // 
+            // injectGlitch3ToolStripMenuItem
+            // 
+            this.injectGlitch3ToolStripMenuItem.Name = "injectGlitch3ToolStripMenuItem";
+            this.injectGlitch3ToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            this.injectGlitch3ToolStripMenuItem.Text = "Inject RGH1.3/RGH3 ECC";
+            this.injectGlitch3ToolStripMenuItem.Click += new System.EventHandler(this.injectGlitch3ToolStripMenuItem_Click);
+            // 
             // jRPToolStripMenuItem
             // 
             this.jRPToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -1424,34 +1461,6 @@ namespace JRunner
             this.keyDatabaseToolStripMenuItem.Text = "Key Database";
             this.keyDatabaseToolStripMenuItem.Click += new System.EventHandler(this.keyDatabaseToolStripMenuItem_Click);
             // 
-            // experimentalToolStripMenuItem
-            // 
-            this.experimentalToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.g3fixToolStripMenuItem,
-            this.zeroPairSbToolStripMenuItem});
-            this.experimentalToolStripMenuItem.Name = "experimentalToolStripMenuItem";
-            this.experimentalToolStripMenuItem.Size = new System.Drawing.Size(240, 22);
-            this.experimentalToolStripMenuItem.Text = "Experimental Features";
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(237, 6);
-            // 
-            // g3fixToolStripMenuItem
-            // 
-            this.g3fixToolStripMenuItem.Name = "g3fixToolStripMenuItem";
-            this.g3fixToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.g3fixToolStripMenuItem.Text = "G3fix patch";
-            this.g3fixToolStripMenuItem.Click += new System.EventHandler(this.g3fixToolStripMenuItem_Click);
-            // 
-            // zeroPairSbToolStripMenuItem
-            // 
-            this.zeroPairSbToolStripMenuItem.Name = "zeroPairSbToolStripMenuItem";
-            this.zeroPairSbToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.zeroPairSbToolStripMenuItem.Text = "Zero pair SB";
-            this.zeroPairSbToolStripMenuItem.Click += new System.EventHandler(this.zeroPairSbToolStripMenuItem_Click);
-            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1650,5 +1659,6 @@ namespace JRunner
         private ToolStripMenuItem experimentalToolStripMenuItem;
         private ToolStripMenuItem g3fixToolStripMenuItem;
         private ToolStripMenuItem zeroPairSbToolStripMenuItem;
+        private ToolStripMenuItem injectGlitch3ToolStripMenuItem;
     }
 }

--- a/J-Runner/MainForm.cs
+++ b/J-Runner/MainForm.cs
@@ -3423,6 +3423,49 @@ namespace JRunner
             
         }
 
+        private void injectGlitch3ToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(variables.filename1))
+            {
+                MessageBox.Show("No nand loaded in source", "Can't", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (!Nand.Nand.VerifyKey(Oper.StringToByteArray(variables.cpukey)))
+            {
+                Console.WriteLine("Bad CPU Key");
+                return;
+            }
+
+            if (!nand.cpukeyverification(variables.cpukey))
+            {
+                Console.WriteLine("Wrong CPU Key");
+                return;
+            }
+
+            OpenFileDialog ofd = new OpenFileDialog();
+            ofd.Filter = "Glitch3 ECC (*.ecc)|*.ecc|All files (*.*)|*.*";
+            ofd.Title = "Select RGH1.3 or RGH3 ECC file";
+            ofd.InitialDirectory = variables.rootfolder;
+            ofd.RestoreDirectory = false;
+
+            if (ofd.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            if (xPanel.getRbtnGlitch2mChecked())
+            {
+                // MFG loaders and by extension Glitch2m images encrypt the CB_B differently
+                // than retail CB_B, so we need to use a zero CPU key for invoking rgh3build
+                rgh3Build.injectECC(ofd.FileName, "00000000000000000000000000000000");
+            }
+            else
+            {
+                rgh3Build.injectECC(ofd.FileName, variables.cpukey);
+            }
+        }
+
         CustomXeBuild CX;
         private void CustomXeBuildMenuItem_Click(object sender, EventArgs e)
         {

--- a/J-Runner/MainForm.resx
+++ b/J-Runner/MainForm.resx
@@ -120,9 +120,6 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>917, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>917, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="btnIPGetCPU.BtnImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
Adds a menu item to show an open file dialog where a user can select an RGH3 or RGH 1.3 ECC to inject into the current image. Calls the same RGH2to3 function in the backend. Works for converting to RGH 1.3 with any of the numerous ECCs out there or injecting an updated RGH3 ECC without overwriting what's included with JRunner