### PR TITLE
Checkbox to apply HddSsAuthPatch

### DIFF
--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -50,6 +50,7 @@ namespace JRunner.Classes
         private bool _xlboth;
         private bool _usbdsec;
         private bool _coronakeyfix;
+        private bool _hddssauth;
         private Nand.PrivateN _nand;
         private List<string> _patches;
 
@@ -471,7 +472,7 @@ namespace JRunner.Classes
             Nand.Nand.zeroPairDevkitSb(Path.Combine(variables.xefolder, variables.updflash), true);
         }
 
-        public void loadvariables(string cpukey, variables.hacktypes ttype, string dash, consoles ctype, List<string> patches, Nand.PrivateN nand, bool altoptions, bool DLpatches, bool includeLaunch, bool audclamp, bool rjtag, bool cleansmc, bool cr4, bool smcp, bool rgh3, bool bigffs, bool zfuse, bool xdkbuild, bool xlusb, bool xlhdd, bool xlboth, bool usbdsec, bool coronakeyfix, bool fullDataClean)
+        public void loadvariables(string cpukey, variables.hacktypes ttype, string dash, consoles ctype, List<string> patches, Nand.PrivateN nand, bool altoptions, bool DLpatches, bool includeLaunch, bool audclamp, bool rjtag, bool cleansmc, bool cr4, bool smcp, bool rgh3, bool bigffs, bool zfuse, bool xdkbuild, bool xlusb, bool xlhdd, bool xlboth, bool usbdsec, bool coronakeyfix, bool hddssauth, bool fullDataClean)
         {
             this._cpukey = cpukey;
             this._ttype = ttype;
@@ -496,6 +497,7 @@ namespace JRunner.Classes
             this._xlboth = xlboth;
             this._usbdsec = usbdsec;
             this._coronakeyfix = coronakeyfix;
+            this._hddssauth = hddssauth;
             this._fullDataClean = fullDataClean;
         }
 
@@ -1182,6 +1184,7 @@ namespace JRunner.Classes
 
             if (_usbdsec) arguments += " -a usbdsec";
             if (_coronakeyfix) arguments += " -a corona_key_fix";
+            if (_hddssauth) arguments += " -a hddssauth";
 
             foreach (String patch in _patches)
             {

--- a/J-Runner/Panels/XeBuildPanel.cs
+++ b/J-Runner/Panels/XeBuildPanel.cs
@@ -566,6 +566,13 @@ namespace JRunner.Panels
             }
             else chkUsbdSec.Checked = chkUsbdSec.Enabled = false;
 
+            if (File.Exists(Path.Combine(variables.updatepath, comboDash.SelectedValue + @"\bin\hddssauth.bin")))
+            {
+                if (rbtnRetail.Checked) chkHddSsAuth.Checked = chkHddSsAuth.Enabled = false;
+                else chkHddSsAuth.Enabled = true;
+            }
+            else chkHddSsAuth.Checked = chkHddSsAuth.Enabled = false;
+
             checkDashAndConsoleSpecificPatches(variables.boardtype);
         }
 
@@ -1008,6 +1015,12 @@ namespace JRunner.Panels
             else Console.WriteLine("Corona Key Fix deselected");
         }
 
+        private void chkHddSsAuth_CheckedChanged(object sender, EventArgs e)
+        {
+            if (chkHddSsAuth.Checked) Console.WriteLine("HddSsAuth selected");
+            else Console.WriteLine("HddSsAuth deselected");
+        }
+
         private void btnGetMB_Click(object sender, EventArgs e)
         {
             if ((ModifierKeys & Keys.Shift) == Keys.Shift && MainForm.mainForm.device == MainForm.DEVICE.XFLASHER_SPI) MainForm.mainForm.xflasher.getConsoleCb();
@@ -1322,7 +1335,7 @@ namespace JRunner.Panels
             xe.loadvariables(nand._cpukey, (variables.hacktypes)variables.ttyp, variables.dashversion,
                              variables.ctype, patches, nand, chkXeSettings.Checked, checkDLPatches.Checked,
                              chkLaunch.Checked, chkAudClamp.Checked, chkRJtag.Checked, chkCleanSMC.Checked, chkCR4.Checked, chkSMCP.Checked, chkRgh3.Checked, chkBigffs.Checked,
-                             chk0Fuse.Checked, chkXdkBuild.Checked, chkXLUsb.Checked, chkXLHdd.Checked, chkXLBoth.Checked, chkUsbdSec.Checked, chkCoronaKeyFix.Checked, fullDataClean);
+                             chk0Fuse.Checked, chkXdkBuild.Checked, chkXLUsb.Checked, chkXLHdd.Checked, chkXLBoth.Checked, chkUsbdSec.Checked, chkCoronaKeyFix.Checked, chkHddSsAuth.Checked, fullDataClean);
 
             string ini = (variables.launchpath + @"\" + variables.dashversion + @"\_" + variables.ttyp + ".ini");
 
@@ -1474,7 +1487,7 @@ namespace JRunner.Panels
                             chkLaunch.Checked, chkAudClamp.Checked, chkRJtag.Checked, chkCleanSMC.Checked,
                             chkCR4.Checked, chkSMCP.Checked, chkRgh3.Checked, chkBigffs.Checked, chk0Fuse.Checked,
                             chkXdkBuild.Checked, chkXLUsb.Checked, chkXLHdd.Checked, chkXLBoth.Checked, chkUsbdSec.Checked,
-                            chkCoronaKeyFix.Checked, fullDataClean);
+                            chkCoronaKeyFix.Checked, chkHddSsAuth.Checked, fullDataClean);
                         goto Start;
                     }
                 case Classes.xebuild.XebuildError.none:

--- a/J-Runner/Panels/XeBuildPanel.designer.cs
+++ b/J-Runner/Panels/XeBuildPanel.designer.cs
@@ -62,6 +62,7 @@
             this.rbtnGlitch = new System.Windows.Forms.RadioButton();
             this.tabPatches = new System.Windows.Forms.TabPage();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.chkHddSsAuth = new System.Windows.Forms.CheckBox();
             this.chkCoronaKeyFix = new System.Windows.Forms.CheckBox();
             this.chkUsbdSec = new System.Windows.Forms.CheckBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -105,7 +106,6 @@
             this.chkNoWrite = new System.Windows.Forms.CheckBox();
             this.btnXEUpdate = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.chkHddSsAuth = new System.Windows.Forms.CheckBox();
             this.groupBox7.SuspendLayout();
             this.MainTabs.SuspendLayout();
             this.tabXeBuild.SuspendLayout();
@@ -535,6 +535,20 @@
             this.groupBox2.TabIndex = 8;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Other Patches";
+            // 
+            // chkHddSsAuth
+            // 
+            this.chkHddSsAuth.AutoSize = true;
+            this.chkHddSsAuth.Enabled = false;
+            this.chkHddSsAuth.Location = new System.Drawing.Point(21, 56);
+            this.chkHddSsAuth.Name = "chkHddSsAuth";
+            this.chkHddSsAuth.Size = new System.Drawing.Size(80, 17);
+            this.chkHddSsAuth.TabIndex = 2;
+            this.chkHddSsAuth.Text = "HddSsAuth";
+            this.toolTip1.SetToolTip(this.chkHddSsAuth, "Patch Freeboot to do full auth for drives with a security sector,\r\nallowing FATXP" +
+        "lorer retail formatted drives with unused space \r\nto be detected and used.");
+            this.chkHddSsAuth.UseVisualStyleBackColor = true;
+            this.chkHddSsAuth.CheckedChanged += new System.EventHandler(this.chkHddSsAuth_CheckedChanged);
             // 
             // chkCoronaKeyFix
             // 
@@ -1029,20 +1043,6 @@
             this.btnXEUpdate.Text = "Update";
             this.btnXEUpdate.UseVisualStyleBackColor = true;
             this.btnXEUpdate.Click += new System.EventHandler(this.btnXEUpdate_Click);
-            // 
-            // chkHddSsAuth
-            // 
-            this.chkHddSsAuth.AutoSize = true;
-            this.chkHddSsAuth.Enabled = false;
-            this.chkHddSsAuth.Location = new System.Drawing.Point(21, 56);
-            this.chkHddSsAuth.Name = "chkHddSsAuth";
-            this.chkHddSsAuth.Size = new System.Drawing.Size(80, 17);
-            this.chkHddSsAuth.TabIndex = 2;
-            this.chkHddSsAuth.Text = "HddSsAuth";
-            this.toolTip1.SetToolTip(this.chkHddSsAuth, "Patch Freeboot to do full auth for drives with a security sector, allowing FATXPl" +
-        "orer retail formatted drives with \"unused space\" to be detected and used.");
-            this.chkHddSsAuth.UseVisualStyleBackColor = true;
-            this.chkHddSsAuth.CheckedChanged += new System.EventHandler(this.chkHddSsAuth_CheckedChanged);
             // 
             // XeBuildPanel
             // 

--- a/J-Runner/Panels/XeBuildPanel.designer.cs
+++ b/J-Runner/Panels/XeBuildPanel.designer.cs
@@ -105,6 +105,7 @@
             this.chkNoWrite = new System.Windows.Forms.CheckBox();
             this.btnXEUpdate = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.chkHddSsAuth = new System.Windows.Forms.CheckBox();
             this.groupBox7.SuspendLayout();
             this.MainTabs.SuspendLayout();
             this.tabXeBuild.SuspendLayout();
@@ -525,11 +526,12 @@
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.chkHddSsAuth);
             this.groupBox2.Controls.Add(this.chkCoronaKeyFix);
             this.groupBox2.Controls.Add(this.chkUsbdSec);
             this.groupBox2.Location = new System.Drawing.Point(210, 3);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(104, 61);
+            this.groupBox2.Size = new System.Drawing.Size(104, 80);
             this.groupBox2.TabIndex = 8;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Other Patches";
@@ -1028,6 +1030,20 @@
             this.btnXEUpdate.UseVisualStyleBackColor = true;
             this.btnXEUpdate.Click += new System.EventHandler(this.btnXEUpdate_Click);
             // 
+            // chkHddSsAuth
+            // 
+            this.chkHddSsAuth.AutoSize = true;
+            this.chkHddSsAuth.Enabled = false;
+            this.chkHddSsAuth.Location = new System.Drawing.Point(21, 56);
+            this.chkHddSsAuth.Name = "chkHddSsAuth";
+            this.chkHddSsAuth.Size = new System.Drawing.Size(80, 17);
+            this.chkHddSsAuth.TabIndex = 2;
+            this.chkHddSsAuth.Text = "HddSsAuth";
+            this.toolTip1.SetToolTip(this.chkHddSsAuth, "Patch Freeboot to do full auth for drives with a security sector, allowing FATXPl" +
+        "orer retail formatted drives with \"unused space\" to be detected and used.");
+            this.chkHddSsAuth.UseVisualStyleBackColor = true;
+            this.chkHddSsAuth.CheckedChanged += new System.EventHandler(this.chkHddSsAuth_CheckedChanged);
+            // 
             // XeBuildPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1136,5 +1152,6 @@
         private System.Windows.Forms.CheckBox chkXLBoth;
         private System.Windows.Forms.CheckBox chkCoronaKeyFix;
         private System.Windows.Forms.CheckBox chkElpis;
+        private System.Windows.Forms.CheckBox chkHddSsAuth;
     }
 }

--- a/J-Runner/Panels/XeBuildPanel.resx
+++ b/J-Runner/Panels/XeBuildPanel.resx
@@ -120,17 +120,8 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>293, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>293, 17</value>
-  </metadata>
   <metadata name="dashBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>137, 17</value>
-  </metadata>
-  <metadata name="dashBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>137, 17</value>
-  </metadata>
-  <metadata name="dashDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
   </metadata>
   <metadata name="dashDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>

--- a/J-Runner/Panels/XeBuildPanel.resx
+++ b/J-Runner/Panels/XeBuildPanel.resx
@@ -120,8 +120,17 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>293, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>293, 17</value>
+  </metadata>
   <metadata name="dashBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>137, 17</value>
+  </metadata>
+  <metadata name="dashBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>137, 17</value>
+  </metadata>
+  <metadata name="dashDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="dashDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>


### PR DESCRIPTION
Refer to https://github.com/Pheeeeenom/J-Runner-with-Extras-Files/pull/19 for details on the patch.

This is the JRunner side of the optional HddSsAuth patch that forces full retail auth for drives with a security sector, resolving some issues with hard drives and SSDs hacked to have a security sector for retail compatibility.