### PR TITLE
Fix typo causing incorrect warnings for PicoFlasher

### DIFF
--- a/J-Runner/Classes/PicoFlasher.cs
+++ b/J-Runner/Classes/PicoFlasher.cs
@@ -204,7 +204,7 @@ namespace JRunner
             UInt32 flashconfig = RecvUInt32(serial);
             string flashconfigStr = flashconfig.ToString("X8");
 
-            if (flashconfig != 0x00000000 && flashconfig != 0xFFFFFFFF) Console.WriteLine("Flash Config: 0x" + flashconfig.ToString("X8"));
+            if (flashconfig != 0x00000000 && flashconfig != 0xFFFFFFFF) Console.WriteLine("Flash Config: 0x" + flashconfigStr);
 
             if (flashconfig == 0x00000000 || flashconfig == 0xFFFFFFFF)
             {

--- a/J-Runner/Classes/PicoFlasher.cs
+++ b/J-Runner/Classes/PicoFlasher.cs
@@ -202,7 +202,7 @@ namespace JRunner
             SendCmd(serial, cmd);
 
             UInt32 flashconfig = RecvUInt32(serial);
-            string flashconfigStr = flashconfig.ToString("X");
+            string flashconfigStr = flashconfig.ToString("X8");
 
             if (flashconfig != 0x00000000 && flashconfig != 0xFFFFFFFF) Console.WriteLine("Flash Config: 0x" + flashconfig.ToString("X8"));
 


### PR DESCRIPTION
FlashConfig warning string wasn't being padded to 8 characters with zeros.... this fixes that, and should prevent the warning from appearing.