### PR TITLE
Apply the xebuild workaround to all xsb consoles, fix comments

### DIFF
--- a/J-Runner/Classes/xebuild.cs
+++ b/J-Runner/Classes/xebuild.cs
@@ -993,13 +993,16 @@ namespace JRunner.Classes
 
         private bool postBuildActionsAreRequired()
         {
+            //
             // So far, the following image types require post-build actions
             // any others should be added here to prevent errors and file conflicts
             //
-            // 1) XDKBuild when the hack type is NOT DevGL
+            // 1) XDKBuild glitch2m images (we need to inject the SC)
             // 2) Any type of RGH3 image
             // 3) DevGL images for console types 3 (64mb Xenon), 13 (64mb Zephyr), and 14 (64mb Falcon)
+            // 4) Any image type affected by the XeBuild bug where the patch slot size or KV offset is unset
             //
+
             if( (_xdkbuild && _ttype == variables.hacktypes.glitch2m) ||
                 _rgh3 ||
                 isDevglFor64MbConsoles() ||
@@ -1036,11 +1039,17 @@ namespace JRunner.Classes
 
         private bool isAffectedByXeBuildImageBug()
         {
-            // If we've selected the following options, we're building an image
-            // that is affected by a bug in XeBuild that doesn't set the patch slot
-            // size correctly and need to patch the resulting image.
-            if ( (_ttype == variables.hacktypes.retail || _ttype == variables.hacktypes.glitch2m || _ttype == variables.hacktypes.devgl) &&
-                 ( _ctype.ID == 2 || _ctype.ID == 3 || _ctype.ID == 8 ) )
+            // If we're building an image for one of the following console types,
+            // it is potentially affected by a bug in XeBuild that doesn't set the
+            // patch slot size and/or the KV offset and we need to patch the resulting image.
+
+            if ( _ctype.ID == 2  || // 16mb Falcon
+                 _ctype.ID == 3  || // 16mb Zephyr
+                 _ctype.ID == 5  || // 16mb Jasper XSB
+                 _ctype.ID == 7  || // 64mb Xenon
+                 _ctype.ID == 8  || // 16mb Xenon
+                 _ctype.ID == 13 || // 64mb Zephyr
+                 _ctype.ID == 14 )  // 64mb Falcon
             {
                 return true;
             }
@@ -1272,9 +1281,9 @@ namespace JRunner.Classes
                 //
                 if (success && postBuildActionsAreRequired())
                 {
-                    // For DevGL and Glitch2m, there is a bug in XeBuild that breaks falcon board types.
-                    // To fix the image, we need to set the DWORD at 0x70 in NAND (the patch slot address)
-                    // otherwise the CB/CD/CE patches won't be able to find the vfuses
+                    // There are bugs in XeBuild that break images generated for XSB consoles
+                    // - Patch slot size being unset results in XeLL but no dash
+                    // - KV offset being unset means XeLL won't show console details (DVD key, serial, etc.)
                     if(isAffectedByXeBuildImageBug())
                     {
                         Nand.Nand.fixBuggyXeBuildImage(Path.Combine(variables.xefolder, variables.updflash));

--- a/J-Runner/Nand/Nand.cs
+++ b/J-Runner/Nand/Nand.cs
@@ -3124,10 +3124,10 @@ namespace JRunner.Nand
         }
 
         /// <summary>
-        /// Fixes the patch slot size in NAND for Falcon DevGL and Glitch2m images. XeBuild has an apparent
-        /// bug where for Falcon board type only, the patch slot size is set to 0x00000000, rather than the
-        /// expected 0x00010000. This causes bootloader panics in the CB/CD. XDKBuild and dev images don't
-        /// use patch slots so the bug didn't really appear before now.
+        /// Fixes the various bugs that XeBuild has when generating images for XSB consoles
+        /// - For Falcon and Jasper XSB, the patch slot size is set to 0x00000000 rather than the
+        /// expected 0x00010000. This causes the 2BL and 4BL to panic.
+        /// - For Xenon, the KV offset is not set causing XeLL to be unable to show the DVD key, console serial, etc.
         /// </summary>
         /// <param name="flashFilePath">Flash image to be patched, result will be written back to the same file</param>
         public static void fixBuggyXeBuildImage(string flashFilePath)
@@ -3196,8 +3196,8 @@ namespace JRunner.Nand
                 nandPatchPages = unecc(nandPatchPages);
             }
 
-            // Set the patch slot size to 0x00010000, which is the same for all other
-            // image types and glitch2m/DevGL on other board types
+            // If the patch slot size is unset, set the patch slot size to 0x00010000
+            // which is the size for all common image types
             if( 0 == BitConverter.ToInt32(nandPatchPages.Skip(0x70).Take(0x4).ToArray(),0) )
             {
                 Console.WriteLine("Fixing patch slot size set to zero...");
@@ -3209,7 +3209,7 @@ namespace JRunner.Nand
             }
 
 
-            // Set the KV size to 0x00004000 (this is assuming a retail KV)
+            // If the KV size is unset, set the KV size to 0x00004000 (this is assuming a retail KV)
             if (0 == BitConverter.ToInt32(nandPatchPages.Skip(0x60).Take(0x4).ToArray(), 0))
             {
                 Console.WriteLine("Fixing KV size set to zero...");


### PR DESCRIPTION
It was noticed that the XeBuild image bugs also appear to affect Jasper XSB and xenon 64mb.

Rather than trying to add yet another special case, this change will make sure we check and patch *all* image types for affected XSB consoles. PSB and KSB consoles appear to be unaffected.

This change also updates some related comments